### PR TITLE
Don't automatically setup logging on config load

### DIFF
--- a/fedora_messaging/cli.py
+++ b/fedora_messaging/cli.py
@@ -76,6 +76,7 @@ def cli(conf):
             config.conf.load_config(filename=conf)
         except ValueError as e:
             raise click.exceptions.BadParameter(e)
+        config.conf.setup_logging()
 
 
 @cli.command()

--- a/fedora_messaging/config.py
+++ b/fedora_messaging/config.py
@@ -388,10 +388,14 @@ class LazyConfig(dict):
             self.load_config()
         return super(LazyConfig, self).update(*args, **kw)
 
+    def setup_logging(self):
+        if not self.loaded:
+            self.load_config()
+        logging.config.dictConfig(self['log_config'])
+
     def load_config(self, filename=None):
         self.loaded = True
         self.update(load(filename=filename))
-        logging.config.dictConfig(self['log_config'])
         return self
 
 


### PR DESCRIPTION
Otherwise it may overwrite logging when the config object is used from
client applications.