### PR TITLE
Don't hang on Python 2.7 if the broker isn't running

### DIFF
--- a/fedora_messaging/tests/integration/test_publish_consume.py
+++ b/fedora_messaging/tests/integration/test_publish_consume.py
@@ -35,7 +35,11 @@ class PubSubTests(unittest.TestCase):
         time.sleep(5)
 
         for _ in range(0, 3):
-            api.publish(msg)
+            try:
+                api.publish(msg)
+            except exceptions.ConnectionException:
+                consumer_process.terminate()
+                self.fail('Failed to publish message, is the broker running?')
 
         consumer_process.join(timeout=30)
         self.assertEqual(0, consumer_process.exitcode)


### PR DESCRIPTION
It looks like Python 3 will kill the process a connection error is
raised, but Python 2 doesn't. This adds some explicit cleanup.

Signed-off-by: Jeremy Cline <jcline@redhat.com>