### PR TITLE
Note that validate should not be overridden

### DIFF
--- a/fedora_messaging/message.py
+++ b/fedora_messaging/message.py
@@ -185,6 +185,8 @@ class Message(object):
         """
         Validate the headers and body with the message schema, if any.
 
+        .. warning:: This method should not be overridden by sub-classes.
+
         Raises:
             jsonschema.ValidationError: If either the message headers or the message body
                 are invalid.


### PR DESCRIPTION
Add a big red warning for developers to not override validate.

From the discussion on https://github.com/fedora-infra/fedora-messaging/pull/9