### PR TITLE
Have the Message class carry the properties as an attribute

### DIFF
--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import inspect
-import json
 import logging
 import signal
 import ssl
@@ -164,10 +163,12 @@ class PublisherSession(object):
             if self._confirms:
                 self._channel.confirm_delivery()
 
-        body = json.dumps(message.body).encode('utf-8')
-        routing_key = message.topic.encode('utf-8')
         self._channel.publish(
-            exchange, routing_key, body, message.properties)
+            exchange=exchange,
+            routing_key=message.encoded_routing_key,
+            body=message.encoded_body,
+            properties=message.properties,
+        )
 
 
 class ConsumerSession(object):

--- a/fedora_messaging/message.py
+++ b/fedora_messaging/message.py
@@ -21,6 +21,7 @@ this class in a small Python package of its own. Note that at this time, the
 entry point name is unused.
 """
 
+import datetime
 import json
 import logging
 import uuid
@@ -199,9 +200,10 @@ class Message(object):
         # Consumers use this to determine what schema to use and if they're out
         # of date.
         headers['fedora_messaging_schema'] = _schema_name(self.__class__)
+        message_id = "{}.{}".format(datetime.date.today().year, uuid.uuid4())
         return pika.BasicProperties(
             content_type='application/json', content_encoding='utf-8', delivery_mode=2,
-            headers=headers, message_id=str(uuid.uuid4())
+            headers=headers, message_id=message_id,
         )
 
     @property

--- a/fedora_messaging/tests/unit/test_message.py
+++ b/fedora_messaging/tests/unit/test_message.py
@@ -15,6 +15,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import json
 import unittest
 
 import jsonschema
@@ -93,6 +94,17 @@ class MessageTests(unittest.TestCase):
         properties = object()
         msg = message.Message(properties=properties)
         self.assertEqual(msg.properties, properties)
+
+    def test_encoded_routing_key(self):
+        """Assert encoded routing key is correct."""
+        msg = message.Message(topic='test.topic')
+        self.assertEqual(msg.encoded_routing_key, b'test.topic')
+
+    def test_encoded_body(self):
+        """Assert encoded body is correct."""
+        body = {"foo": "barr\u00e9"}
+        msg = message.Message(body=body)
+        self.assertEqual(msg.encoded_body, json.dumps(body).encode("utf-8"))
 
 
 class ClassRegistryTests(unittest.TestCase):

--- a/fedora_messaging/tests/unit/test_session.py
+++ b/fedora_messaging/tests/unit/test_session.py
@@ -80,13 +80,6 @@ class PublisherSessionTests(unittest.TestCase):
         self.assertEqual(publish_call[0], None)
         self.assertEqual(publish_call[1], b"test.topic")
         self.assertEqual(publish_call[2], b'"test body"')
-        properties = publish_call[3]
-        self.assertEqual(properties.content_type, "application/json")
-        self.assertEqual(properties.content_encoding, "utf-8")
-        self.assertEqual(properties.delivery_mode, 2)
-        self.assertDictEqual(properties.headers, {
-            'fedora_messaging_schema': "mock.mock:Mock",
-        })
 
     def test_publish_rejected(self):
         # Check that the correct exception is raised when the publication is
@@ -121,11 +114,11 @@ class PublisherSessionTests(unittest.TestCase):
         channel_mock = mock.Mock()
         connection_class_mock.return_value = connection_mock
         connection_mock.channel.return_value = channel_mock
+        self.message.properties = "properties"
         with mock.patch(
                 "fedora_messaging._session.pika.BlockingConnection",
                 connection_class_mock):
-            self.publisher._connect_and_publish(
-                None, b"test.topic", b'"test body"', "properties")
+            self.publisher._connect_and_publish(None, self.message)
         connection_class_mock.assert_called_with(self.publisher._parameters)
         channel_mock.confirm_delivery.assert_called_once()
         channel_mock.publish.assert_called_with(

--- a/fedora_messaging/twisted/protocol.py
+++ b/fedora_messaging/twisted/protocol.py
@@ -23,7 +23,6 @@ See https://twistedmatrix.com/documents/current/core/howto/clients.html#protocol
 
 from __future__ import absolute_import
 
-import json
 import logging
 
 import pika
@@ -236,10 +235,12 @@ class FedoraMessagingProtocol(TwistedProtocolConnection):
         .. _exchange: https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchanges
         """
         message.validate()
-        body = json.dumps(message.body).encode('utf-8')
-        routing_key = message.topic.encode('utf-8')
-        yield self._channel.publish(
-            exchange, body, routing_key, message.properties)
+        yield self._channel.basic_publish(
+            exchange=exchange,
+            routing_key=message.encoded_routing_key,
+            body=message.encoded_body,
+            properties=message.properties,
+        )
 
     @defer.inlineCallbacks
     def resumeProducing(self):


### PR DESCRIPTION
I wonder if you think that would be a good idea. The Message class is already carrying the topic, I think it makes sense if the properties are stored there too.

One big plus: the `message_id` would be created on instantiation and would be always accessible, which is pretty cool to log when something goes wrong or to identify a message.

What do you think @jeremycline ?