### PR TITLE
Hide the JSON body and properties from users of messages

### DIFF
--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -4,7 +4,7 @@
 Messages
 ========
 
-Before release your application, you should create a subclass of
+Before you release your application, you should create a subclass of
 :class:`fedora_messaging.message.Message`, define a schema, and implement
 some methods.
 
@@ -67,6 +67,14 @@ Schema are Immutable
 Message schema should be treated as immutable. Once defined, they should not be
 altered. Instead, define a new schema class, mark the old one as deprecated,
 and remove it after an appropriate transition period.
+
+Provide Accessors
+-----------------
+
+The JSON schema ensures the message sent "on the wire" conforms to a particular
+format. Messages should provide Python properties to access the deserialized
+JSON object. This Python API should maintain backwards compatibility between
+schema. This shields consumers from changes in schema.
 
 
 Packaging

--- a/docs/sample_schema_package/mailman_schema/schema.py
+++ b/docs/sample_schema_package/mailman_schema/schema.py
@@ -13,15 +13,44 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""This is an example of a message schema."""
+
 from fedora_messaging import message
 
 
-class Message(message.Message):
+class BaseMessage(message.Message):
+    """
+    You should create a super class that each schema version inherits from.
+    This lets consumers perform ``isinstance(msg, BaseMessage)`` if they are
+    receiving multiple message types and allows the publisher to change the
+    schema as long as they preserve the Python API.
+    """
+
+    def __str__(self):
+        """Return a complete human-readable representation of the message."""
+        return 'Subject: {subj}\n{body}\n'.format(
+            subj=self.subject, body=self.body)
+
+    def summary(self):
+        """Return a summary of the message."""
+        return self.subject
+
+    @property
+    def subject(self):
+        """The email's subject."""
+        return 'Message did not implement "subject" property'
+
+    @property
+    def body(self):
+        """The email message body."""
+        return 'Message did not implement "body" property'
+
+
+class MessageV1(BaseMessage):
     """
     A sub-class of a Fedora message that defines a message schema for messages
     published by Mailman when it receives mail to send out.
     """
-
     body_schema = {
         'id': 'http://fedoraproject.org/message-schema/mailman#',
         '$schema': 'http://json-schema.org/draft-04/schema#',
@@ -60,11 +89,56 @@ class Message(message.Message):
         'required': ['mlist', 'msg'],
     }
 
-    def __str__(self):
-        """Return a complete human-readable representation of the message."""
-        return 'Subject: {subj}\n\n{body}\n'.format(
-            subj=self.body['msg']['subject'], body=self.body['msg']['body'])
+    @property
+    def subject(self):
+        """The email's subject."""
+        return self._body['msg']['subject']
 
-    def summary(self):
-        """Return a summary of the message."""
-        return self.body['msg']['subject']
+    @property
+    def body(self):
+        """The email message body."""
+        return self._body['msg']['body']
+
+
+class MessageV2(BaseMessage):
+    """
+    This is a revision from the MessageV1 schema which flattens the message
+    structure into a single object, but is backwards compatible for any users
+    that make use of the properties (``subject`` and ``body``).
+    """
+
+    body_schema = {
+        'id': 'http://fedoraproject.org/message-schema/mailman#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Schema for message sent to mailman',
+        'type': 'object',
+        'required': ['mailing_list', 'from', 'to', 'subject', 'body'],
+        'properties': {
+            'mailing_list': {
+                    'type': 'string',
+                    'description': 'The name of the mailing list',
+            },
+            'delivered-to': {'type': 'string'},
+            'from': {'type': 'string'},
+            'cc': {'type': 'string'},
+            'to': {'type': 'string'},
+            'x-mailman-rule-hits': {'type': 'string'},
+            'x-mailman-rule-misses': {'type': 'string'},
+            'x-message-id-hash': {'type': 'string'},
+            'references': {'type': 'string'},
+            'in-reply-to': {'type': 'string'},
+            'message-id': {'type': 'string'},
+            'subject': {'type': 'string'},
+            'body': {'type': 'string'},
+        },
+    }
+
+    @property
+    def subject(self):
+        """The email's subject."""
+        return self._body['subject']
+
+    @property
+    def body(self):
+        """The email message body."""
+        return self._body['body']

--- a/docs/tutorial/schemas.rst
+++ b/docs/tutorial/schemas.rst
@@ -121,7 +121,7 @@ from the message, or to create a human-readable representation.
 Change the ``__str__()`` method to use the expected items from the message body. For example::
 
     return '{owner} did something to the {package} package'.format(
-        owner=self.body['owner'], package=self.body['package']['name'])
+        owner=self._body['owner'], package=self._body['package']['name'])
 
 Also edit the ``summary()`` method to return something relevant.
 

--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -165,9 +165,9 @@ class PublisherSession(object):
 
         self._channel.publish(
             exchange=exchange,
-            routing_key=message.encoded_routing_key,
-            body=message.encoded_body,
-            properties=message.properties,
+            routing_key=message._encoded_routing_key,
+            body=message._encoded_body,
+            properties=message._properties,
         )
 
 

--- a/fedora_messaging/tests/unit/test_message.py
+++ b/fedora_messaging/tests/unit/test_message.py
@@ -35,7 +35,7 @@ class MessageTests(unittest.TestCase):
     def test_str(self):
         """Assert calling str on a message produces a human-readable result."""
         msg = message.Message(topic='test.topic', body={'my': 'key'})
-        expected_headers = json.dumps(msg.headers, sort_keys=True, indent=4)
+        expected_headers = json.dumps(msg._headers, sort_keys=True, indent=4)
         expected = ('Id: {}\nTopic: test.topic\n'
                     'Headers: {}'
                     '\nBody: {{\n    "my": "key"\n}}').format(
@@ -74,41 +74,41 @@ class MessageTests(unittest.TestCase):
 
     def test_properties_default(self):
         msg = message.Message()
-        self.assertEqual(msg.properties.content_type, "application/json")
-        self.assertEqual(msg.properties.content_encoding, "utf-8")
-        self.assertEqual(msg.properties.delivery_mode, 2)
-        self.assertIn("sent-at", msg.properties.headers)
-        self.assertIn("fedora_messaging_schema", msg.properties.headers)
+        self.assertEqual(msg._properties.content_type, "application/json")
+        self.assertEqual(msg._properties.content_encoding, "utf-8")
+        self.assertEqual(msg._properties.delivery_mode, 2)
+        self.assertIn("sent-at", msg._properties.headers)
+        self.assertIn("fedora_messaging_schema", msg._properties.headers)
         self.assertEqual(
-            msg.properties.headers["fedora_messaging_schema"],
+            msg._properties.headers["fedora_messaging_schema"],
             "fedora_messaging.message:Message"
         )
 
     def test_headers(self):
         msg = message.Message(headers={"foo": "bar"})
-        self.assertIn("foo", msg.properties.headers)
-        self.assertEqual(msg.properties.headers["foo"], "bar")
+        self.assertIn("foo", msg._properties.headers)
+        self.assertEqual(msg._properties.headers["foo"], "bar")
         # The fedora_messaging_schema key must also be added when headers are given.
         self.assertEqual(
-            msg.properties.headers['fedora_messaging_schema'],
+            msg._properties.headers['fedora_messaging_schema'],
             "fedora_messaging.message:Message",
         )
 
     def test_properties(self):
         properties = object()
         msg = message.Message(properties=properties)
-        self.assertEqual(msg.properties, properties)
+        self.assertEqual(msg._properties, properties)
 
     def test_encoded_routing_key(self):
         """Assert encoded routing key is correct."""
         msg = message.Message(topic='test.topic')
-        self.assertEqual(msg.encoded_routing_key, b'test.topic')
+        self.assertEqual(msg._encoded_routing_key, b'test.topic')
 
     def test_encoded_body(self):
         """Assert encoded body is correct."""
         body = {"foo": "barr\u00e9"}
         msg = message.Message(body=body)
-        self.assertEqual(msg.encoded_body, json.dumps(body).encode("utf-8"))
+        self.assertEqual(msg._encoded_body, json.dumps(body).encode("utf-8"))
 
 
 class ClassRegistryTests(unittest.TestCase):

--- a/fedora_messaging/tests/unit/test_session.py
+++ b/fedora_messaging/tests/unit/test_session.py
@@ -41,11 +41,11 @@ class PublisherSessionTests(unittest.TestCase):
         self.publisher._connection = mock.Mock()
         self.publisher._channel = mock.Mock()
         self.message = mock.Mock()
-        self.message.headers = {}
+        self.message._headers = {}
         self.message.topic = "test.topic"
-        self.message.encoded_routing_key = b"test.topic"
-        self.message.body = "test body"
-        self.message.encoded_body = b'"test body"'
+        self.message._encoded_routing_key = b"test.topic"
+        self.message._body = "test body"
+        self.message._encoded_body = b'"test body"'
         self.tls_conf = {
             'keyfile': None,
             'certfile': None,
@@ -116,7 +116,7 @@ class PublisherSessionTests(unittest.TestCase):
         channel_mock = mock.Mock()
         connection_class_mock.return_value = connection_mock
         connection_mock.channel.return_value = channel_mock
-        self.message.properties = "properties"
+        self.message._properties = "properties"
         with mock.patch(
                 "fedora_messaging._session.pika.BlockingConnection",
                 connection_class_mock):
@@ -326,7 +326,7 @@ class ConsumerSessionMessageTests(unittest.TestCase):
         msg = self.consumer._consumer_callback.call_args_list[0][0][0]
         msg.validate.assert_called_once()
         self.channel.basic_ack.assert_called_with(delivery_tag="testtag")
-        self.assertEqual(msg.body, "test body")
+        self.assertEqual(msg._body, "test body")
 
     def test_message_encoding(self):
         body = '"test body unicode é à ç"'.encode("utf-8")
@@ -334,7 +334,7 @@ class ConsumerSessionMessageTests(unittest.TestCase):
         self.consumer._on_message(self.channel, self.frame, self.properties, body)
         self.consumer._consumer_callback.assert_called_once()
         msg = self.consumer._consumer_callback.call_args_list[0][0][0]
-        self.assertEqual(msg.body, "test body unicode é à ç")
+        self.assertEqual(msg._body, "test body unicode é à ç")
 
     def test_message_wrong_encoding(self):
         body = '"test body unicode é à ç"'.encode("utf-8")

--- a/fedora_messaging/twisted/protocol.py
+++ b/fedora_messaging/twisted/protocol.py
@@ -237,9 +237,9 @@ class FedoraMessagingProtocol(TwistedProtocolConnection):
         message.validate()
         yield self._channel.basic_publish(
             exchange=exchange,
-            routing_key=message.encoded_routing_key,
-            body=message.encoded_body,
-            properties=message.properties,
+            routing_key=message._encoded_routing_key,
+            body=message._encoded_body,
+            properties=message._properties,
         )
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Publishers shouldn't need to touch these after creation, and consumers
should not be digging in the raw JSON as this makes migrating from one
schema to another difficult. Instead, we should wrap the JSON object in
Python methods which form the public API of the message.