### PR TITLE
Make the message summary a property

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,16 @@
 Release Notes
 =============
 
+master
+======
+
+API Changes
+-----------
+
+* ``fedora_messaging.message.Message.summary`` is now a property rather than
+  a method.
+
+
 v1.0.0a1
 ========
 

--- a/docs/consuming.rst
+++ b/docs/consuming.rst
@@ -140,7 +140,7 @@ called when a message arrives::
                 message (fedora_messaging.api.Message): The message from AMQP.
             """
             if self.summary:
-                print(message.summary())
+                print(message.summary)
             else:
                 print(message)
 

--- a/docs/sample_schema_package/mailman_schema/tests/test_schema.py
+++ b/docs/sample_schema_package/mailman_schema/tests/test_schema.py
@@ -87,7 +87,7 @@ class MessageV1Tests(unittest.TestCase):
         """Assert the summary matches the message subject."""
         message = self.msg_class(body=self.full_message)
 
-        self.assertEqual('A sample email', message.summary())
+        self.assertEqual('A sample email', message.summary)
 
     def test_subject(self):
         """Assert the message provides a "subject" attribute."""

--- a/docs/tutorial/conversion.rst
+++ b/docs/tutorial/conversion.rst
@@ -103,7 +103,7 @@ dumped to JSON. The schema could be written as::
         'required': ['agent', 'election'],
     }
 
-Use this schema and adapt the ``__str__()`` and ``summary()`` methods.
+Use this schema and adapt the ``__str__()`` method and the ``summary`` property.
 
 Since the schema is distributed in a separate python package, it must be added
 to the ``election`` app's dependencies in ``requirements.txt``.

--- a/docs/tutorial/schemas.rst
+++ b/docs/tutorial/schemas.rst
@@ -123,7 +123,7 @@ Change the ``__str__()`` method to use the expected items from the message body.
     return '{owner} did something to the {package} package'.format(
         owner=self._body['owner'], package=self._body['package']['name'])
 
-Also edit the ``summary()`` method to return something relevant.
+Also edit the ``summary`` property to return something relevant.
 
 
 Testing it

--- a/fedora_messaging/message.py
+++ b/fedora_messaging/message.py
@@ -236,6 +236,18 @@ class Message(object):
         """The encoded body used to publish the message."""
         return json.dumps(self._body).encode('utf-8')
 
+    @property
+    def summary(self):
+        """
+        A short, human-readable representation of this message.
+
+        This should provide a short summary of the message, much like the subject line
+        of an email.
+
+        The default implementation is to simply return the message topic.
+        """
+        return self.topic
+
     def __str__(self):
         """
         A human-readable representation of this message.
@@ -272,17 +284,6 @@ class Message(object):
         """
         return (isinstance(other, self.__class__) and self.topic == other.topic and
                 self._body == other._body and self._headers == other._headers)
-
-    def summary(self):
-        """
-        A short, human-readable representation of this message.
-
-        This should provide a short summary of the message, much like the subject line
-        of an email.
-
-        The default implementation is to simply return the message topic.
-        """
-        return self.topic
 
     def validate(self):
         """

--- a/fedora_messaging/tests/unit/test_message.py
+++ b/fedora_messaging/tests/unit/test_message.py
@@ -30,7 +30,7 @@ class MessageTests(unittest.TestCase):
     def test_summary(self):
         """Assert message summaries default to the message topic."""
         msg = message.Message(topic='test.topic')
-        self.assertEqual(msg.topic, msg.summary())
+        self.assertEqual(msg.topic, msg.summary)
 
     def test_str(self):
         """Assert calling str on a message produces a human-readable result."""


### PR DESCRIPTION
The ``summary`` method on the ``fedora_messaging.message.Message`` class
is now a property.

This came up during the Flock session so I thought it'd be good to get the change in ASAP and kick out a second alpha.