### PR TITLE
Fix authentication with x509 certificates

### DIFF
--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -63,6 +63,7 @@ def _configure_tls_parameters(parameters):
     if cert and key:
         _log.info('Authenticating with server using x509 (certfile: %s, keyfile: %s)',
                   cert, key)
+        parameters.credentials = pika.credentials.ExternalCredentials()
     else:
         cert, key = None, None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ blinker
 click
 jsonschema
 pytoml
-pika
+pika>=0.12
 six


### PR DESCRIPTION
The connection parameters need to set the credentials type to 'EXTERNAL'
in order for x509 client certificate authentication to work. Do so if
both the cert and key is present.

Signed-off-by: Jeremy Cline <jcline@redhat.com>