### PR TITLE
Add an example consumer callback

### DIFF
--- a/fedora_messaging/example.py
+++ b/fedora_messaging/example.py
@@ -1,0 +1,32 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Example consumers that can be used when starting out with the library to test."""
+from __future__ import print_function
+
+import six
+
+
+def printer(message):
+    """
+    A simple callback that prints the message to standard output.
+
+    Usage: ``fedora-messaging consume --callback="fedora_messaging.example:printer"``
+
+    Args:
+        message (fedora_messaging.api.Message): The message that was received.
+    """
+    print(six.text_type(message))

--- a/fedora_messaging/message.py
+++ b/fedora_messaging/message.py
@@ -229,7 +229,7 @@ class Message(object):
         return self._properties.headers
 
     @_headers.setter
-    def _headers_setter(self, value):
+    def _headers(self, value):
         self._properties.headers = value
 
     @property
@@ -237,7 +237,7 @@ class Message(object):
         return self._properties.message_id
 
     @id.setter
-    def id_setter(self, value):
+    def id(self, value):
         self._properties.message_id = value
 
     @property

--- a/fedora_messaging/message.py
+++ b/fedora_messaging/message.py
@@ -325,8 +325,10 @@ class Message(object):
         return "Id: {i}\nTopic: {t}\nHeaders: {h}\nBody: {b}".format(
             i=self.id,
             t=self.topic,
-            h=json.dumps(self._headers, sort_keys=True, indent=4),
-            b=json.dumps(self._body, sort_keys=True, indent=4),
+            h=json.dumps(
+                self._headers, sort_keys=True, indent=4, separators=(",", ": ")
+            ),
+            b=json.dumps(self._body, sort_keys=True, indent=4, separators=(",", ": ")),
         )
 
     @property

--- a/fedora_messaging/tests/unit/test_example.py
+++ b/fedora_messaging/tests/unit/test_example.py
@@ -1,0 +1,53 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Tests for :mod:`fedora_messaging.example`."""
+
+try:
+    from io import StringIO
+except ImportError:
+    # Python 2
+    from StringIO import StringIO
+import unittest
+
+import mock
+
+from fedora_messaging import api, example
+
+
+class PrinterTests(unittest.TestCase):
+    def test_printer(self):
+        """Assert the printer callback prints messages."""
+        message = api.Message(body=u"Hello world", topic=u"hi")
+        message._headers = {
+            "fedora_messaging_schema": "fedora_messaging.message:Message",
+            "sent-at": "2018-08-22T00:00:00",
+        }
+        message.id = "95383db8-8cdc-4464-8276-d482ac28b0b6"
+        expected_stdout = (
+            u"Id: 95383db8-8cdc-4464-8276-d482ac28b0b6\n"
+            u"Topic: hi\n"
+            u"Headers: {\n"
+            u'    "fedora_messaging_schema": "fedora_messaging.message:Message",\n'
+            u'    "sent-at": "2018-08-22T00:00:00"\n'
+            u"}\n"
+            u'Body: "Hello world"\n'
+        )
+
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            example.printer(message)
+
+        self.assertEqual(expected_stdout, mock_stdout.getvalue())

--- a/fedora_messaging/tests/unit/test_message.py
+++ b/fedora_messaging/tests/unit/test_message.py
@@ -35,7 +35,9 @@ class MessageTests(unittest.TestCase):
     def test_str(self):
         """Assert calling str on a message produces a human-readable result."""
         msg = message.Message(topic="test.topic", body={"my": "key"})
-        expected_headers = json.dumps(msg._headers, sort_keys=True, indent=4)
+        expected_headers = json.dumps(
+            msg._headers, sort_keys=True, indent=4, separators=(",", ": ")
+        )
         expected = (
             "Id: {}\nTopic: test.topic\n"
             "Headers: {}"


### PR DESCRIPTION
I found myself regularly wanting a callback available to test with, so this just adds a simple printer callback. This also led to the discovery of a few small issues when I wrote a test, so those have been fixed as well.