### PR TITLE
Add a severity to messages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,6 +46,18 @@ Message Schemas
 .. automodule:: fedora_messaging.message
    :members: Message, get_class
 
+Message Severity
+----------------
+
+Each message can have a severity associated with it. The severity is used by
+applications like the notification service to determine what messages to send
+to users. The severity can be set at the class level, or on a message-by-message
+basis. The following are valid severity levels:
+
+.. autodata:: fedora_messaging.message.DEBUG
+.. autodata:: fedora_messaging.message.INFO
+.. autodata:: fedora_messaging.message.WARNING
+.. autodata:: fedora_messaging.message.ERROR
 
 .. _exceptions-api:
 

--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -5,8 +5,8 @@ Messages
 ========
 
 Before you release your application, you should create a subclass of
-:class:`fedora_messaging.message.Message`, define a schema, and implement
-some methods.
+:class:`fedora_messaging.message.Message`, define a schema, define a default
+severity, and implement some methods.
 
 Schema
 ======
@@ -33,9 +33,10 @@ Message schema are defined using `JSON Schema`_.
 Header Schema
 -------------
 
-The default header schema simply declares that the header field must be a JSON
-object. You can leave the schema as-is when you define your own message, or
-refine it.
+The default header schema declares that the header field must be a JSON object
+with several expected keys. You can leave the schema as-is when you define your
+own message, or you can refine it. The base schema will always be enforced in
+addition to your custom schema.
 
 
 .. _body-schema:


### PR DESCRIPTION
Each message can now have a severity associated with it, both at a class
level and on a message-by-message basis.

Signed-off-by: Jeremy Cline <jcline@redhat.com>