### PR TITLE
Remove the unused --amqp-url parameter from the CLI

### DIFF
--- a/docs/fedora-messaging.rst
+++ b/docs/fedora-messaging.rst
@@ -73,11 +73,6 @@ consume
     digits, hyphen, underscore, period, or colon. If one is not specified, the
     default is the ``amq.topic`` exchange.
 
-``--amqp-url``
-
-    The AMQP URL to connect to, in the format
-    ``scheme://username:password@host:port/virtual_host?key=value&key=value``.
-    Consult the `pika`_ documentation for the supported query string parameters.
 
 Help
 ====

--- a/fedora_messaging/cli.py
+++ b/fedora_messaging/cli.py
@@ -63,11 +63,6 @@ _exchange_help = (
     "digits, hyphen, underscore, period, or colon. If one is not specified, the "
     "default is the ``amq.topic`` exchange."
 )
-_amqp_url_help = (
-    "The AMQP URL to connect to, in the format "
-    "scheme://user:pass@host:port/virtual_host?key=value&key=value. Consult "
-    "the pika documentation for the supported query string parameters."
-)
 
 
 @click.group()
@@ -90,10 +85,8 @@ def cli(conf):
 @click.option("--routing-key", help=_routing_key_help)
 @click.option("--queue-name", help=_queue_name_help)
 @click.option("--exchange", help=_exchange_help)
-@click.option("--amqp-url", help=_amqp_url_help)
-def consume(amqp_url, exchange, queue_name, routing_key, callback, app_name):
+def consume(exchange, queue_name, routing_key, callback, app_name):
     """Consume messages from an AMQP queue using a Python callback."""
-    amqp_url = amqp_url or config.conf["amqp_url"]
     if exchange and queue_name and routing_key:
         bindings = [
             {"exchange": exchange, "queue_name": queue_name, "routing_key": routing_key}

--- a/fedora_messaging/tests/unit/test_cli.py
+++ b/fedora_messaging/tests/unit/test_cli.py
@@ -91,8 +91,7 @@ class ConsumeCliTests(unittest.TestCase):
         )
 
     @mock.patch.dict(
-        "fedora_messaging.config.conf",
-        {"amqp_url": "a", "bindings": None, "callback": "mod:callable"},
+        "fedora_messaging.config.conf", {"bindings": None, "callback": "mod:callable"}
     )
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
@@ -124,8 +123,7 @@ class ConsumeCliTests(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     @mock.patch.dict(
-        "fedora_messaging.config.conf",
-        {"amqp_url": "a", "bindings": "b", "callback": "mod:callable"},
+        "fedora_messaging.config.conf", {"bindings": "b", "callback": "mod:callable"}
     )
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
@@ -139,8 +137,7 @@ class ConsumeCliTests(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     @mock.patch.dict(
-        "fedora_messaging.config.conf",
-        {"amqp_url": "a", "bindings": None, "callback": "mod:callable"},
+        "fedora_messaging.config.conf", {"bindings": None, "callback": "mod:callable"}
     )
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
@@ -167,8 +164,7 @@ class ConsumeCliTests(unittest.TestCase):
         self.assertEqual(1, result.exit_code)
 
     @mock.patch.dict(
-        "fedora_messaging.config.conf",
-        {"amqp_url": "a", "bindings": None, "callback": "mod:callable"},
+        "fedora_messaging.config.conf", {"bindings": None, "callback": "mod:callable"}
     )
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
@@ -186,7 +182,7 @@ class ConsumeCliTests(unittest.TestCase):
         )
         self.assertEqual(1, result.exit_code)
 
-    @mock.patch.dict("fedora_messaging.config.conf", {"amqp_url": "a", "bindings": "b"})
+    @mock.patch.dict("fedora_messaging.config.conf", {"bindings": "b"})
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
     def test_good_cli_callable(self, mock_consume, mock_importlib):
@@ -202,8 +198,7 @@ class ConsumeCliTests(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
     @mock.patch.dict(
-        "fedora_messaging.config.conf",
-        {"amqp_url": "a", "bindings": "b", "callback": None},
+        "fedora_messaging.config.conf", {"bindings": "b", "callback": None}
     )
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
@@ -220,7 +215,7 @@ class ConsumeCliTests(unittest.TestCase):
         )
         self.assertEqual(1, result.exit_code)
 
-    @mock.patch.dict("fedora_messaging.config.conf", {"amqp_url": "a", "bindings": "b"})
+    @mock.patch.dict("fedora_messaging.config.conf", {"bindings": "b"})
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
     def test_cli_callable_wrong_format(self, mock_consume, mock_importlib):
@@ -241,7 +236,7 @@ class ConsumeCliTests(unittest.TestCase):
         )
         self.assertEqual(1, result.exit_code)
 
-    @mock.patch.dict("fedora_messaging.config.conf", {"amqp_url": "a", "bindings": "b"})
+    @mock.patch.dict("fedora_messaging.config.conf", {"bindings": "b"})
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
     def test_cli_callable_import_failure(self, mock_consume, mock_importlib):
@@ -261,7 +256,7 @@ class ConsumeCliTests(unittest.TestCase):
         self.assertEqual(1, result.exit_code)
 
     @mock.patch("fedora_messaging.cli.getattr")
-    @mock.patch.dict("fedora_messaging.config.conf", {"amqp_url": "a", "bindings": "b"})
+    @mock.patch.dict("fedora_messaging.config.conf", {"bindings": "b"})
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
     def test_callable_getattr_failure(self, mock_consume, mock_importlib, mock_getattr):
@@ -285,7 +280,7 @@ class ConsumeCliTests(unittest.TestCase):
         )
         self.assertEqual(1, result.exit_code)
 
-    @mock.patch.dict("fedora_messaging.config.conf", {"amqp_url": "a", "bindings": "b"})
+    @mock.patch.dict("fedora_messaging.config.conf", {"bindings": "b"})
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
     def test_consume_improper_callback_object(self, mock_consume, mock_importlib):
@@ -305,7 +300,7 @@ class ConsumeCliTests(unittest.TestCase):
         self.assertIn(error_message, result.output)
         self.assertEqual(2, result.exit_code)
 
-    @mock.patch.dict("fedora_messaging.config.conf", {"amqp_url": "a", "bindings": "b"})
+    @mock.patch.dict("fedora_messaging.config.conf", {"bindings": "b"})
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
     def test_consume_halt_with_exitcode(self, mock_consume, mock_importlib):
@@ -331,7 +326,7 @@ class ConsumeCliTests(unittest.TestCase):
         )
         self.assertEqual(halt_exit_code, result.exit_code)
 
-    @mock.patch.dict("fedora_messaging.config.conf", {"amqp_url": "a", "bindings": "b"})
+    @mock.patch.dict("fedora_messaging.config.conf", {"bindings": "b"})
     @mock.patch("fedora_messaging.cli.importlib")
     @mock.patch("fedora_messaging.cli.api.consume")
     def test_consume_halt_without_exitcode(self, mock_consume, mock_importlib):


### PR DESCRIPTION
At the moment the only way to specify the AMQP URL is via the
configuration file. Until someone asks for the ability to specify it on
the CLI, just stick with that.

fixes #45

Signed-off-by: Jeremy Cline <jcline@redhat.com>