### PR TITLE
Depend on service_identity for proper TLS client cert checking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytoml
 pytz
 pika>=0.12
 six
+service_identity


### PR DESCRIPTION
service_identity is an optional dependency of pyOpenSSL for users who
don't enjoy getting MITMed. Rather than leaving it up to the users to
just know this is an optional dependency they want, include it as a hard
requirement.

Signed-off-by: Jeremy Cline <jcline@redhat.com>