### PR TITLE
Allow exchange type to be specified and pass on binding arguments

### DIFF
--- a/fedora_messaging/tests/unit/twisted/test_protocol.py
+++ b/fedora_messaging/tests/unit/twisted/test_protocol.py
@@ -116,20 +116,24 @@ class ProtocolTests(unittest.TestCase):
         self.factory.bindings = [
             {
                 "exchange": "testexchange1",
+                "exchange_type": "topic",
                 "queue_name": "testqueue1",
                 "routing_key": "#",
             },
             {
                 "exchange": "testexchange2",
+                "exchange_type": "topic",
                 "queue_name": "testqueue2",
                 "queue_auto_delete": True,
                 "routing_key": "testrk",
             },
             {
                 "exchange": "testexchange3",
+                "exchange_type": "headers",
                 "queue_name": "testqueue3",
                 "routing_key": "#",
                 "queue_arguments": {},
+                "binding_arguments": {"x-match": "all"},
             },
         ]
         callback = mock.Mock()
@@ -163,7 +167,7 @@ class ProtocolTests(unittest.TestCase):
                         (),
                         dict(
                             exchange="testexchange3",
-                            exchange_type="topic",
+                            exchange_type="headers",
                             durable=True,
                         ),
                     ),
@@ -210,6 +214,7 @@ class ProtocolTests(unittest.TestCase):
                             exchange="testexchange1",
                             queue="testqueue1",
                             routing_key="#",
+                            arguments=None,
                         ),
                     ),
                     (
@@ -218,6 +223,7 @@ class ProtocolTests(unittest.TestCase):
                             exchange="testexchange2",
                             queue="testqueue2",
                             routing_key="testrk",
+                            arguments=None,
                         ),
                     ),
                     (
@@ -226,6 +232,7 @@ class ProtocolTests(unittest.TestCase):
                             exchange="testexchange3",
                             queue="testqueue3",
                             routing_key="#",
+                            arguments={"x-match": "all"},
                         ),
                     ),
                 ],

--- a/fedora_messaging/twisted/protocol.py
+++ b/fedora_messaging/twisted/protocol.py
@@ -109,7 +109,9 @@ class FedoraMessagingProtocol(TwistedProtocolConnection):
         self._message_callback = message_callback
         for binding in self.factory.bindings:
             yield self._channel.exchange_declare(
-                exchange=binding["exchange"], exchange_type="topic", durable=True
+                exchange=binding["exchange"],
+                exchange_type=binding["exchange_type"],
+                durable=True,
             )
             result = yield self._channel.queue_declare(
                 queue=binding["queue_name"],
@@ -122,6 +124,7 @@ class FedoraMessagingProtocol(TwistedProtocolConnection):
                 queue=queue_name,
                 exchange=binding["exchange"],
                 routing_key=binding["routing_key"],
+                arguments=binding.get("binding_arguments"),
             )
             self._queues.add(queue_name)
         log.msg("AMQP bindings declared", system=self.name, logLevel=logging.DEBUG)

--- a/fedora_messaging/twisted/service.py
+++ b/fedora_messaging/twisted/service.py
@@ -37,23 +37,30 @@ from .factory import FedoraMessagingFactory
 
 
 class FedoraMessagingService(service.MultiService):
-    """A Twisted service to connect to the Fedora Messaging broker."""
+    """
+    A Twisted service to connect to the Fedora Messaging broker.
+
+    Args:
+        on_message (callable|None): Callback that will be passed each
+            incoming messages. If None, no message consuming is setup.
+        amqp_url (str): URL to use for the AMQP server.
+        bindings (list(dict)): A list of dictionaries that define queue
+            bindings to exchanges. This parameter can be used to override the
+            bindings declared in the configuration. See the configuration
+            documentation for details. Each dictionary should contain the
+            following keys: "exchange", "exchange_type", "queue_name",
+            "routing_key", "queue_auto_delete", "queue_arguments", and
+            "binding_arguments" (which are passed to
+            :meth:`pika.channel.Channel.queue_declare` and
+            :meth:`pika.channel.Channel.queue_bind` respectively as the
+            ``arguments`` key.
+    """
 
     name = "fedora-messaging"
     factoryClass = FedoraMessagingFactory
 
     def __init__(self, on_message, amqp_url=None, bindings=None):
-        """Initialize the service.
-
-        Args:
-            on_message (callable|None): Callback that will be passed each
-                incoming messages. If None, no message consuming is setup.
-            amqp_url (str): URL to use for the AMQP server.
-            bindings (list(dict)): A list of dictionaries that define queue
-                bindings to exchanges. This parameter can be used to override
-                the bindings declared in the configuration. See the
-                configuration documentation for details.
-        """
+        """Initialize the service."""
         service.MultiService.__init__(self)
         amqp_url = amqp_url or config.conf["amqp_url"]
         self._parameters = pika.URLParameters(amqp_url)


### PR DESCRIPTION
This allows users to bind to header exchanges, which provide routing
configuration via the bind arguments.

Signed-off-by: Jeremy Cline <jcline@redhat.com>