### PR TITLE
Use towncrier to generate the changelog

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ mock
 twisted
 pytest-twisted
 pyOpenSSL
+towncrier

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Release Notes
 =============
 
+.. towncrier release notes start
+
 v1.0.0b1
 ========
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,12 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../"))  # NOQA
+
+import fedora_messaging
 
 
 # -- Project information -----------------------------------------------------
@@ -24,9 +27,9 @@ copyright = "2018, Red Hat, Inc"
 author = "Fedora Infrastructure"
 
 # The short X.Y version
-version = "1.0"
+version = ".".join(fedora_messaging.__version__.split(".")[:2])
 # The full version, including alpha/beta/rc tags
-release = "1.0.0b1"
+release = fedora_messaging.__version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -55,6 +55,31 @@ Your pull request should contain tests for your new feature or bug fix. If
 you're not certain how to write tests, we will be happy to help you.
 
 
+Release notes
+-------------
+To add entries to the release notes, create a file in the ``news`` directory
+with the ``source.type`` name format, where ``type`` is one of:
+
+* ``feature``: for new features
+* ``bug``: for bug fixes
+* ``api``: for API changes
+* ``dev``: for development-related changes
+* ``author``: for contributor names
+* ``other``: for other changes
+
+And where the ``source`` part of the filename is:
+
+* ``42`` when the change is described in issue ``42``
+* ``PR42`` when the change has been implemented in pull request ``42``, and
+  there is no associated issue
+* ``Cabcdef`` when the change has been implemented in changeset ``abcdef``, and
+  there is no associated issue or pull request.
+* ``username`` for contributors (``author`` extention). It should be the
+  username part of their commits' email address.
+
+A preview of the release notes can be generated with ``towncrier --draft``.
+
+
 Licensing
 ---------
 
@@ -101,3 +126,23 @@ address, indicating that you agree to the `Developer Certificate of Origin
 	    this project or the open source license(s) involved.
 
 Use ``git commit -s`` to add the Signed-off-by tag.
+
+
+Releasing
+---------
+
+When cutting a new release, follow these steps:
+
+* update the version in ``fedora_messaging/__init__.py``
+* update the version in ``docs/conf.py``
+* generate the changelog by running ``towncrier``
+* change the ``Development Status`` classifier in ``setup.py`` if necessary
+* commit the changes
+* tag the commit
+* push to GitHub
+* generate a tarball and push to PyPI with the commands:
+
+::
+
+    python setup.py sdist bdist_wheel
+    twine upload -s dist/*

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -134,7 +134,6 @@ Releasing
 When cutting a new release, follow these steps:
 
 * update the version in ``fedora_messaging/__init__.py``
-* update the version in ``docs/conf.py``
 * generate the changelog by running ``towncrier``
 * change the ``Development Status`` classifier in ``setup.py`` if necessary
 * commit the changes

--- a/fedora_messaging/__init__.py
+++ b/fedora_messaging/__init__.py
@@ -14,3 +14,5 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+__version__ = "1.0.0b1"

--- a/news/PR51.feature
+++ b/news/PR51.feature
@@ -1,0 +1,1 @@
+Ensure proper TLS client cert checking with ``service_identity``.

--- a/news/PR53.feature
+++ b/news/PR53.feature
@@ -1,0 +1,1 @@
+Support Python 3.7.

--- a/news/PR56.api
+++ b/news/PR56.api
@@ -1,0 +1,1 @@
+The unused ``exchange`` parameter from the PublisherSession was removed.

--- a/news/PR63.feature
+++ b/news/PR63.feature
@@ -1,0 +1,1 @@
+Allow the exchange type to be specified.

--- a/news/PR65.api
+++ b/news/PR65.api
@@ -1,0 +1,1 @@
+Add a new ``queue`` attribute to messages.

--- a/news/PR67.dev
+++ b/news/PR67.dev
@@ -1,0 +1,1 @@
+Use `towncrier <https://github.com/hawkowl/towncrier>`_ to generate the release notes.

--- a/news/PR68.dev
+++ b/news/PR68.dev
@@ -1,0 +1,1 @@
+Check that our dependencies have Free licenses.

--- a/news/_template.rst
+++ b/news/_template.rst
@@ -1,0 +1,58 @@
+{% macro issue_url(value) -%}
+   {%- if value.startswith("PR") -%}
+     `PR#{{ value[2:] }} <https://github.com/fedora-infra/fedora-messaging/pull/{{ value[2:] }}>`_
+   {%- elif value.startswith("C") -%}
+     `{{ value[1:] }} <https://github.com/fedora-infra/fedora-messaging/commit/{{ value[1:] }}>`_
+   {%- else -%}
+     `#{{ value }} <https://github.com/fedora-infra/fedora-messaging/issues/{{ value }}>`_
+   {%- endif -%}
+{%- endmacro -%}
+
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section] and category != "author" %}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+* {{ text }}
+  ({% for value in values -%}
+      {{ issue_url(value) }}
+      {%- if not loop.last %}, {% endif -%}
+   {%- endfor %})
+
+{% endfor %}
+{% else %}
+* {{ sections[section][category]['']|sort|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+
+{% endfor %}
+{% if sections[section]["author"] %}
+{{definitions['author']["name"]}}
+{{ underline * definitions['author']['name']|length }}
+Many thanks to the contributors of bug reports, pull requests, and pull request
+reviews for this release:
+
+{% for text, values in sections[section]["author"].items() %}
+* {{ text }}
+{% endfor %}
+{% endif %}
+
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}

--- a/news/aurelien.author
+++ b/news/aurelien.author
@@ -1,0 +1,1 @@
+Aurélien Bompard

--- a/news/get-authors.py
+++ b/news/get-authors.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+from subprocess import check_output
+
+authors = {}
+output = check_output(["git", "log", "--format=%ae\t%an"], universal_newlines=True)
+for line in output.splitlines():
+    email, fullname = line.split("\t")
+    email = email.split("@")[0].replace(".", "")
+    if email in authors:
+        continue
+    authors[email] = fullname
+
+for nick, fullname in authors.items():
+    with open("{}.author".format(nick), "w") as f:
+        f.write(fullname)
+        f.write("\n")

--- a/news/jcline.author
+++ b/news/jcline.author
@@ -1,0 +1,1 @@
+Jeremy Cline

--- a/news/swojciechowski89.author
+++ b/news/swojciechowski89.author
@@ -1,0 +1,1 @@
+Sebastian Wojciechowski

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[tool.towncrier]
+package = "fedora_messaging"
+filename = "docs/changelog.rst"
+directory = "news/"
+title_format = "{version} ({project_date})"
+issue_format = "{issue}"
+template = "news/_template.rst"
+
+  [[tool.towncrier.type]]
+  directory = "api"
+  name = "API Changes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "feature"
+  name = "Features"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "bug"
+  name = "Bug Fixes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "dev"
+  name = "Development Changes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "other"
+  name = "Other Changes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "author"
+  name = "Contributors"
+  showcontent = true

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import re
 
 from setuptools import setup, find_packages
 
@@ -8,6 +9,10 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, "README.rst")) as fd:
     README = fd.read()
+
+with open(os.path.join(here, "fedora_messaging", "__init__.py")) as fd:
+    match = re.search('^__version__ = "([^"]+)"$', fd.read(), re.MULTILINE)
+    VERSION = match.group(1)
 
 
 def get_requirements(requirements_file="requirements.txt"):
@@ -45,7 +50,7 @@ def get_requirements(requirements_file="requirements.txt"):
 
 setup(
     name="fedora_messaging",
-    version="1.0.0b1",
+    version=VERSION,
     description="A set of tools for using Fedora's messaging infrastructure",
     long_description=README,
     url="https://github.com/fedora-infra/fedora-messaging",


### PR DESCRIPTION
Towncrier lets us generate release notes in a much more convenient way than what we currently do. Each PR just has to create a file with the line that should end up in the release notes, and the ``changelog.rst`` file can be automatically generated before each release.

I have added documentation in the ``contributing.rst`` file for more usage info.

@jeremycline I would also like you to verify that the releasing process I have documented in ``contributing.rst`` is correct, please.