### PR TITLE
Expand the test matrix for unit and integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,29 +17,69 @@ env:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=py27
+      env: TOXENV=py27-pika1-unittest
     - python: "3.4"
-      env: TOXENV=py34
+      env: TOXENV=py34-pika1-unittest
     - python: "3.5"
-      env: TOXENV=py35
+      env: TOXENV=py35-pika1-unittest
     - python: "3.6"
-      env: TOXENV=py36
+      env: TOXENV=py36-pika1-unittest
     - python: "3.7"
-      env: TOXENV=py37
+      env: TOXENV=py37-pika1-unittest
       dist: xenial
       sudo: required  # Force Travis to use a Ubuntu 16.04 VM that can run 3.7
     - python: "2.7"
-      env: TOXENV=py27-integration
+      env: TOXENV=py27-pika012-unittest
+    - python: "3.4"
+      env: TOXENV=py34-pika012-unittest
+    - python: "3.5"
+      env: TOXENV=py35-pika012-unittest
+    - python: "3.6"
+      env: TOXENV=py36-pika012-unittest
+    - python: "3.7"
+      env: TOXENV=py37-pika012-unittest
+      dist: xenial
+      sudo: required  # Force Travis to use a Ubuntu 16.04 VM that can run 3.7
+    - python: "2.7"
+      env: TOXENV=py27-pika1-integration
+      sudo: required
+      services:
+        - rabbitmq
+    - python: "3.4"
+      env: TOXENV=py34-pika1-integration
+      sudo: required
+      services:
+        - rabbitmq
+    - python: "3.5"
+      env: TOXENV=py35-pika1-integration
       sudo: required
       services:
         - rabbitmq
     - python: "3.6"
-      env: TOXENV=py36-integration
+      env: TOXENV=py36-pika1-integration
+      sudo: required
+      services:
+        - rabbitmq
+    - python: "2.7"
+      env: TOXENV=py27-pika012-integration
+      sudo: required
+      services:
+        - rabbitmq
+    - python: "3.4"
+      env: TOXENV=py34-pika012-integration
+      sudo: required
+      services:
+        - rabbitmq
+    - python: "3.5"
+      env: TOXENV=py35-pika012-integration
       sudo: required
       services:
         - rabbitmq
     - python: "3.6"
-      env: TOXENV=pika_master
+      env: TOXENV=py36-pika012-integration
+      sudo: required
+      services:
+        - rabbitmq
     - python: "3.6"
       env: TOXENV=docs
     - python: "3.6"

--- a/fedora_messaging/tests/unit/twisted/test_protocol.py
+++ b/fedora_messaging/tests/unit/twisted/test_protocol.py
@@ -74,7 +74,7 @@ class MockProtocol(FedoraMessagingProtocol):
     """A Protocol object that mocks the underlying channel and impl."""
 
     def __init__(self, *args, **kwargs):
-        super(MockProtocol, self).__init__(*args, **kwargs)
+        FedoraMessagingProtocol.__init__(self, *args, **kwargs)
         self._impl = mock.Mock(name="_impl")
         self._impl.is_closed = True
         self._channel = MockChannel(name="_channel")

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = lint,format,py27,py34,py35,py36,py37,docs,py27-integration,py36-integration,pika_master,licenses
+envlist = lint,format,licenses,{py27,py34,py35,py36,py37}-pika{012,1}-unittest, {py27,py34,py35,py36,py37}-pika{012,1}-integration
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 deps =
+    pika012: pika==0.12
+    pika1: git+https://github.com/pika/pika.git
     -rdev-requirements.txt
 sitepackages = False
 whitelist_externals =
@@ -13,28 +15,61 @@ commands =
     pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
         --cov-report xml --cov-report html {posargs}
 
-[testenv:pika_master]
-python = python3.6
-deps =
-    git+https://github.com/pika/pika.git
-    -rdev-requirements.txt
-sitepackages = False
-whitelist_externals =
-    rm
-commands =
-    rm -rf htmlcov coverage.xml
-    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
-        --cov-report xml --cov-report html {posargs}
-
-[testenv:py27-integration]
-python = python2.7
+[testenv:py27-pika1-integration]
 commands =
     rm -rf htmlcov coverage.xml
     pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
         --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
 
-[testenv:py36-integration]
-python = python3.6
+[testenv:py34-pika1-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py35-pika1-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py36-pika1-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py37-pika1-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py27-pika012-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py34-pika012-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py35-pika012-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py36-pika012-integration]
+commands =
+    rm -rf htmlcov coverage.xml
+    pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \
+        --cov-report xml --cov-report html {posargs} fedora_messaging/tests/integration
+
+[testenv:py37-pika012-integration]
 commands =
     rm -rf htmlcov coverage.xml
     pytest -vv --cov-config .coveragerc --cov=fedora_messaging --cov-report term \


### PR DESCRIPTION
Add tests for pika 0.12 and 1.0.0 on both unit tests and integration
tests, and expand the integration test matrix for all Python versions.

fixes #53 

Note: I couldn't figure out how to get tox to run a different command for a sub-set of environments, thus the copy/paste :(

Signed-off-by: Jeremy Cline <jcline@redhat.com>