### PR TITLE
Adjust channel and connection on close callbacks to pika 0.12

### DIFF
--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -301,28 +301,18 @@ class ConsumerSession(object):
         _log.info("Successfully opened connection to %s", connection.params.host)
         self._channel = connection.channel(on_open_callback=self._on_channel_open)
 
-    def _on_connection_close(self, connection, reply_code_or_reason, reply_text=None):
+    def _on_connection_close(self, connection, reply_code, reply_text=None):
         """
         Callback invoked when a previously-opened connection is closed.
 
         Args:
             connection (pika.connection.SelectConnection): The connection that
                 was just closed.
-            reply_code_or_reason (int|Exception): The reason why the channel
-                was closed. In older versions of pika, this is the AMQP code.
-            reply_text (str): The human-readable reason the connection was
-                closed (only in older versions of pika)
+            reply_code (int): The reason code why the connection was closed.
+            reply_text (str): The human-readable reason for the connection's
+                closure.
         """
         self._channel = None
-
-        if isinstance(reply_code_or_reason, pika_errs.ConnectionClosed):
-            reply_code = reply_code_or_reason.reply_code
-            reply_text = reply_code_or_reason.reply_text
-        elif isinstance(reply_code_or_reason, int):
-            reply_code = reply_code_or_reason
-        else:
-            reply_code = 0
-            reply_text = str(reply_code_or_reason)
 
         if reply_code == 200:
             # Normal shutdown, exit the consumer.

--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -277,26 +277,16 @@ class ConsumerSession(object):
                 callback=self._on_queue_declareok,
             )
 
-    def _on_channel_close(self, channel, reply_code_or_reason, reply_text=None):
+    def _on_channel_close(self, channel, reply_code, reply_text=None):
         """
         Callback invoked when the channel is closed.
 
         Args:
             channel (pika.channel.Channel): The channel that got closed.
-            reply_code_or_reason (int|Exception): The reason why the channel
-                was closed. In older versions of pika, this is the AMQP code.
+            reply_code (int): The reason code why the channel was closed.
             reply_text (str): The human-readable reason for the channel's
-                closure (only in older versions of pika).
+                closure.
         """
-        if isinstance(reply_code_or_reason, pika_errs.ChannelClosed):
-            reply_code = reply_code_or_reason.reply_code
-            reply_text = reply_code_or_reason.reply_text
-        elif isinstance(reply_code_or_reason, int):
-            reply_code = reply_code_or_reason
-        else:
-            reply_code = 0
-            reply_text = str(reply_code_or_reason)
-
         _log.info("Channel %r closed (%d): %s", channel, reply_code, reply_text)
         self._channel = None
 


### PR DESCRIPTION
From:

https://pika.readthedocs.io/en/stable/modules/connection.html#pika.connection.Connection.add_on_close_callback

Info:
The callback will be passed the connection, the reply_code (int) and the reply_text (str), if sent by the remote server

Can I assume that all of them (connection, the reply_code, the reply_text) remote server can skip, or just reply_text?
