### PR TITLE
Compatibility with Click 7.x

### DIFF
--- a/news/PR86.feature
+++ b/news/PR86.feature
@@ -1,0 +1,1 @@
+Compatibility with `Click <https://click.palletsprojects.com/>`_ 7.x


### PR DESCRIPTION
Click 7.x has a [different signature](https://click.palletsprojects.com/en/7.x/api/#click.BadOptionUsage) for the `BadOptionUsage` exception