### PR TITLE
Use the entry point name as the unique identifier for schema

### DIFF
--- a/docs/tutorial/schemas.rst
+++ b/docs/tutorial/schemas.rst
@@ -40,9 +40,9 @@ containing an important dictionary attribute: ``body_schema``. This is where
 the JSON schema lives.
 
 For clarity, edit the ``setup.py`` file and in the entry points list change the
-``mailman.schema`` name to something more relevant to your app, like
-``yourapp.schema``. The entry point name is currently unused (only the class
-path matters), but you should use something that identifies your app.
+``mailman.messageV1`` name to something more relevant to your app, like
+``yourapp.my_messageV1``. The entry point name needs to be unique to your
+application, so it's best to prefix it with your package or application name.
 
 Schema format
 ~~~~~~~~~~~~~

--- a/docs/wire-format.rst
+++ b/docs/wire-format.rst
@@ -34,9 +34,9 @@ debug-level information, 20 being informational, 30 being warning-level, and 40
 being critically important.
 
 The ``fedora_messaging_schema`` key should be set to a string that uniquely
-identifies the type of message. In the Python library, this is mapped to a
-class containing the schema and a Python API to interact with the message
-object.
+identifies the type of message. In the Python library this is the entry point
+name, which is mapped to a class containing the schema and a Python API to
+interact with the message object.
 
 The header's json-schema is::
 

--- a/fedora_messaging/tests/integration/test_publish_consume.py
+++ b/fedora_messaging/tests/integration/test_publish_consume.py
@@ -104,7 +104,7 @@ def test_basic_pub_sub():
     )
     expected_headers = {
         u"fedora_messaging_severity": 20,
-        u"fedora_messaging_schema": u"fedora_messaging.message:Message",
+        u"fedora_messaging_schema": u"base.message",
         u"niceness": u"very",
     }
     messages_received = []

--- a/news/PR89.api
+++ b/news/PR89.api
@@ -1,0 +1,2 @@
+The name of the entry point is now used to identify the message type. This is
+documented in detail in the wire format.


### PR DESCRIPTION
When working on #88, I realized that using the class path as the unique
ID would be a bit odd when working from a different language. It seems
better to use the entry point name as the unique identifier.

Signed-off-by: Jeremy Cline <jcline@redhat.com>