### PR TITLE
Add a requirements file for readthedocs

### DIFF
--- a/readthedocs.txt
+++ b/readthedocs.txt
@@ -1,0 +1,15 @@
+blinker
+click
+coverage
+jsonschema
+mock
+pika>=0.12
+pytoml
+pytz
+pytest-twisted
+pyOpenSSL
+six
+service_identity
+sphinx
+towncrier
+twisted


### PR DESCRIPTION
pyasn1 is required by service-identity, but pyasn1-modules gets
installed first. This triggers a long-standing setuptools issue which
causes the install to explode. Instead, just have a requirements file
installed with pip and don't install the project in the readthedocs
build.

Right now the docs builder has been failing because it can't install successfully.

Signed-off-by: Jeremy Cline <jcline@redhat.com>