### PR TITLE
Fix docs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Fedora Messaging
 .. image:: https://img.shields.io/pypi/pyversions/fedora-messaging.svg
     :target: https://pypi.org/project/fedora-messaging/
 
-.. image:: https://readthedocs.org/projects/docs/badge/?version=latest
+.. image:: https://readthedocs.org/projects/fedora-messaging/badge/?version=latest
     :alt: Documentation Status
     :target: https://fedora-messaging.readthedocs.io/en/latest/?badge=latest
 


### PR DESCRIPTION
I noticed the docs badge in README.rst is showing failed docs even if they passed.
After looking at it more closely I noticed there is reference to wrong img.

Here is the fix for this.