### PR TITLE
Add consumers to service init and pass to factory

### DIFF
--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -82,12 +82,15 @@ def _configure_tls_parameters(parameters):
         }
     else:
         ssl_context = ssl.create_default_context()
-        try:
-            ssl_context.load_verify_locations(cafile=config.conf["tls"]["ca_cert"])
-        except ssl.SSLError as e:
-            raise ConfigurationException(
-                'The "ca_cert" setting in the "tls" section is invalid ({})'.format(e)
-            )
+        if config.conf["tls"]["ca_cert"]:
+            try:
+                ssl_context.load_verify_locations(cafile=config.conf["tls"]["ca_cert"])
+            except ssl.SSLError as e:
+                raise ConfigurationException(
+                    'The "ca_cert" setting in the "tls" section is invalid ({})'.format(
+                        e
+                    )
+                )
         ssl_context.options |= ssl.OP_NO_SSLv2
         ssl_context.options |= ssl.OP_NO_SSLv3
         ssl_context.options |= ssl.OP_NO_TLSv1

--- a/fedora_messaging/config.py
+++ b/fedora_messaging/config.py
@@ -282,11 +282,7 @@ DEFAULTS = dict(
     qos={"prefetch_size": 0, "prefetch_count": 10},
     callback=None,
     consumer_config={},
-    tls={
-        "ca_cert": "/etc/pki/tls/certs/ca-bundle.crt",
-        "certfile": None,
-        "keyfile": None,
-    },
+    tls={"ca_cert": None, "certfile": None, "keyfile": None},
     log_config={
         "version": 1,
         "disable_existing_loggers": False,


### PR DESCRIPTION
For the sake of convenience, allow services to take a set of consumers
and have it pass them on to the factory.

Signed-off-by: Jeremy Cline <jcline@redhat.com>