### PR TITLE
Start a module for test helpers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ User Guide
    publishing
    consuming
    messages
+   testing
    changelog
 
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,9 @@
+
+.. _testing:
+
+=======
+Testing
+=======
+
+.. automodule:: fedora_messaging.testing
+   :members:

--- a/fedora_messaging/testing.py
+++ b/fedora_messaging/testing.py
@@ -1,0 +1,88 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
+Once you've written code to publish or consume messages, you'll probably want
+to test it. The :mod:`fedora_messaging.testing` module has utilities for common
+test patterns.
+
+If you find yourself implementing a pattern over and over in your test code,
+consider contributing it here!
+"""
+
+from contextlib import contextmanager
+import inspect
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+@contextmanager
+def mock_sends(*expected_messages):
+    """
+    Assert a block of code results in the provided messages being sent without
+    actually sending them.
+
+    This is intended for unit tests. The call to publish is mocked out and messages
+    are captured and checked at the end of the ``with``.
+
+    For example:
+
+        >>> from fedora_messaging import api, testing
+        >>> def publishes():
+        ...     api.publish(api.Message(body={"Hello": "world"}))
+        ...
+        >>> with testing.mock_sends(api.Message, api.Message(body={"Hello": "world"})):
+        ...     publishes()
+        ...     publishes()
+        ...
+        >>> with testing.mock_sends(api.Message(body={"Goodbye": "everybody"})):
+        ...     publishes()
+        ...
+        AssertionError
+
+    Args:
+        *expected_messages: The messages you expect to be sent. These can be classes
+            instances of classes derived from :class:`fedora_messaging.message.Message`.
+            If the class is provided, the message is checked to make sure it is an
+            instance of that class and that it passes schema validation. If an instance
+            is provided, it is checked for equality with the sent message.
+
+    Raises:
+        AssertionError: If the messages published don't match the messages asserted.
+    """
+    with mock.patch("fedora_messaging.api._session_cache") as mock_cache:
+        yield
+        messages = [call[0][0] for call in mock_cache.session.publish.call_args_list]
+        if len(expected_messages) != len(messages):
+            raise AssertionError(
+                "Expected {} messages to be sent, but {} were sent".format(
+                    len(expected_messages), len(messages)
+                )
+            )
+        for msg, expected in zip(messages, expected_messages):
+            if inspect.isclass(expected):
+                if not isinstance(msg, expected):
+                    raise AssertionError(
+                        "Expected message of type {}, but {} was sent".format(
+                            expected, msg.__class__
+                        )
+                    )
+            else:
+                assert msg == expected
+            msg.validate()

--- a/fedora_messaging/tests/unit/test_testing.py
+++ b/fedora_messaging/tests/unit/test_testing.py
@@ -1,0 +1,120 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Tests for the testing utilities."""
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+import unittest
+
+from fedora_messaging import testing, api, message
+
+
+class CustomMessage(api.Message):
+    pass
+
+
+class MockSendsTests(unittest.TestCase):
+    """Tests for the :func:`fedora_messaging.testing.mock_sends` function."""
+
+    def test_class(self):
+        """Assert all goes well if the message published matches the asserted class."""
+
+        def pub():
+            api.publish(api.Message())
+
+        with testing.mock_sends(api.Message):
+            pub()
+
+    def test_instance(self):
+        """Assert all goes well if the message published matches the asserted instance."""
+
+        def pub():
+            api.publish(api.Message())
+
+        with testing.mock_sends(api.Message()):
+            pub()
+
+    def test_expected_none(self):
+        """Assert all goes well if the message published matches the asserted instance."""
+
+        def pub():
+            api.publish(api.Message())
+
+        with self.assertRaises(AssertionError) as cm:
+            with testing.mock_sends():
+                pub()
+        self.assertEqual(
+            "Expected 0 messages to be sent, but 1 were sent", cm.exception.args[0]
+        )
+
+    def test_mix_class_instance(self):
+        """Assert a mix of class and instance works."""
+
+        def pub():
+            api.publish(api.Message())
+            api.publish(CustomMessage())
+
+        with mock.patch.dict(message._class_to_schema_name, {CustomMessage: "custom"}):
+            with testing.mock_sends(api.Message(), CustomMessage):
+                pub()
+
+    def test_mix_class_instance_order_matters(self):
+        """Assert the order of messages matters."""
+        expected_err = (
+            "Expected message of type <class 'fedora_messaging.tests.unit.test_testing"
+            ".CustomMessage'>, but <class 'fedora_messaging.message.Message'> was sent"
+        )
+
+        def pub():
+            api.publish(api.Message())
+            api.publish(CustomMessage())
+
+        with mock.patch.dict(message._class_to_schema_name, {CustomMessage: "custom"}):
+            with self.assertRaises(AssertionError) as cm:
+                with testing.mock_sends(CustomMessage, api.Message()):
+                    pub()
+        self.assertEqual(expected_err, cm.exception.args[0])
+
+    def test_too_many(self):
+        """Assert publishing more messages than expected fails with an AssertionError."""
+
+        def pub():
+            api.publish(api.Message())
+            api.publish(api.Message())
+
+        with self.assertRaises(AssertionError) as cm:
+            with testing.mock_sends(api.Message):
+                pub()
+        self.assertEqual(
+            "Expected 1 messages to be sent, but 2 were sent", cm.exception.args[0]
+        )
+
+    def test_wrong_type(self):
+        """Assert sending the wrong type of message raises an AssertionError."""
+        expected_err = (
+            "Expected message of type <class 'fedora_messaging.tests.unit.test_testing"
+            ".CustomMessage'>, but <class 'fedora_messaging.message.Message'> was sent"
+        )
+
+        def pub():
+            api.publish(api.Message())
+
+        with self.assertRaises(AssertionError) as cm:
+            with testing.mock_sends(CustomMessage):
+                pub()
+        self.assertEqual(expected_err, cm.exception.args[0])


### PR DESCRIPTION
I started moving anitya over to fedora-messaging, and quickly decided I
needed a helper for tests. Since this is generally useful, I thought
it'd be good to add it here and collect other things like this here.

Signed-off-by: Jeremy Cline <jcline@redhat.com>