### PR TITLE
Explicitly configure Travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,19 @@
 language: python
 cache: pip
 
+notifications:
+  email:
+    recipients:
+      - jcline@fedoraproject.org
+      - abompard@fedoraproject.org
+    on_success: never
+    on_failure: always
+  irc:
+    channels:
+      - "chat.freenode.net#fedora-apps"
+    on_success: never
+    on_failure: change
+
 install:
  - pip install --upgrade pip setuptools
  - pip install tox


### PR DESCRIPTION
The default behavior of Travis is to send notifications to the committer
and the author (but only if they have write access) when a build fails.
This no longer works well because mergify is the committer and the
author may not have write access.

Therefore, explicitly configure Travis to notify us via email when a
build fails. Additionally, it will notify the #fedora-apps channel on
freenode when the build first starts to fail.

Signed-off-by: Jeremy Cline <jcline@redhat.com>