### PR TITLE
Make "fedora-messaging consume" useful without a config file

### DIFF
--- a/fedora_messaging/tests/unit/test_config.py
+++ b/fedora_messaging/tests/unit/test_config.py
@@ -418,3 +418,15 @@ class LoadTests(unittest.TestCase):
         mock_log.info.assert_called_once_with(
             "Loading configuration from /etc/fedora-messaging/config.toml"
         )
+
+    def test_load_on_get_item(self):
+        """Assert load_config is called when __getitem__ is invoked."""
+        config = msg_config.LazyConfig()
+        config.load_config = mock.Mock()
+
+        try:
+            config["some_key"]
+        except KeyError:
+            pass
+
+        config.load_config.assert_called_once_with()


### PR DESCRIPTION
In most production cases, there should be a configuration file with all the exchanges, queues, and bindings the application expects to be in place for a particular consumer or publisher. However, the CLI does offer some basic flags that should (in theory) be enough to make it work out of the box without touching a configuration file.

This fixes an issue with "fedora-messaging consume" where when you define a binding, you still need a configuration file with "queues" properly defined or it would do anything useful. Now, a basic queues dictionary is created by the CLI. To make this work, the ``consume`` API call needed to accept the queues argument, which it now does in the second commit in this series. I recommend reviewing this PR commit-by-commit.