### PR TITLE
Setup logging even when a configuration file isn't supplied

### DIFF
--- a/fedora_messaging/cli.py
+++ b/fedora_messaging/cli.py
@@ -77,7 +77,7 @@ def cli(conf):
             config.conf.load_config(config_path=conf)
         except exceptions.ConfigurationException as e:
             raise click.exceptions.BadParameter(str(e))
-        config.conf.setup_logging()
+    config.conf.setup_logging()
 
 
 @cli.command()


### PR DESCRIPTION
If a configuration file wasn't explicitly supplied, logging would not be
set up. Logging should be configured when running the CLI in all cases.

Signed-off-by: Jeremy Cline <jcline@redhat.com>