### PR TITLE
Temporarily pin pytest below 4.1 as it broke pytest-twisted

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ coverage
 sphinx
 mock
 twisted
+pytest<=4.0
 pytest-twisted
 pyOpenSSL
 towncrier


### PR DESCRIPTION
Upstream is working on a fix[0], but until then this will let CI pass.

[0] https://github.com/pytest-dev/pytest-twisted/pull/45

Signed-off-by: Jeremy Cline <jcline@redhat.com>