### PR TITLE
 Allow declaring --exchange/--queue-name/--routing-key independently

### DIFF
--- a/docs/fedora-messaging.rst
+++ b/docs/fedora-messaging.rst
@@ -42,11 +42,19 @@ section below.
 consume
 -------
 
+All options below correspond to settings in the configuration file. However,
+not all available configuration keys can be overridden with options, so it is
+recommended that for complex setups and production environments you use the
+configuration file and no options on the command line.
+
 ``--app-name``
 
     The name of the application, used by the AMQP client to identify itself to
     the broker. This is purely for administrator convenience to determine what
     applications are connected and own particular resources.
+
+    This option is equivalent to the ``app`` setting in the ``client_properties``
+    section of the configuration file.
 
 ``--callback``
 
@@ -55,11 +63,17 @@ consume
     and should point to either a function or a class. Consult the API
     documentation for the interface required for these objects.
 
+    This option is equivalent to the ``callback`` setting in the configuration
+    file.
+
 ``--routing-key``
 
     The AMQP routing key to use with the queue. This controls what messages are
     delivered to the consumer. Can be specified multiple times; any message
     that matches at least one will be placed in the message queue.
+
+    Setting this option is equivalent to setting the ``routing_keys`` setting
+    in *all* ``bindings`` entries in the configuration file.
 
 ``--queue-name``
 
@@ -67,11 +81,18 @@ consume
     hyphen, underscore, period, or colon. If one is not specified, a unique
     name will be created for you.
 
+    Setting this option is equivalent to setting the ``queue`` setting in *all*
+    ``bindings`` entries and creating a ``queue.<queue-name>`` section in the
+    configuration file.
+
 ``--exchange``
 
     The name of the exchange to bind the queue to. Can contain ASCII letters,
     digits, hyphen, underscore, period, or colon. If one is not specified, the
     default is the ``amq.topic`` exchange.
+
+    Setting this option is equivalent to setting the ``exchange`` setting
+    in *all* ``bindings`` entries in the configuration file.
 
 
 Help

--- a/fedora_messaging/config.py
+++ b/fedora_messaging/config.py
@@ -146,16 +146,18 @@ A dictionary of queues that should be present in the broker. Each key should be
 a queue name, and the value should be a dictionary with the queue's configuration.
 Options are:
 
-* ``durable`` - whether or not the queue should survive a broker restart.
+* ``durable`` - whether or not the queue should survive a broker restart. This is
+  set to ``False`` for the default queue.
 
 * ``auto_delete`` - whether or not the queue should be deleted once the
-  consumer disconnects.
+  consumer disconnects. This is set to ``True`` for the default queue.
 
 * ``exclusive`` - whether or not the queue is exclusive to the current
-  connection.
+  connection. This is set to ``False`` for the default queue.
 
 * ``arguments`` - dictionary of arbitrary keyword arguments for the queue, which
-  depends on the broker in use and its extensions.
+  depends on the broker in use and its extensions. This is set to ``{}`` for the
+  default queue
 
 For example::
 


### PR DESCRIPTION
The command-line flags on the consume command are intended to make it
quick and easy to run simple consumers without fiddling with a
configuration file.

To this end, allow users to override --exchange, --queue-name, and
--routing-key, rather than requiring none or all. This brings it in line
with the manual page which states defaults for queue-name and exchange
will be used if they are not provided.

This implementation is simplistic in that it sets all bindings in the
configuration to be for the provided values. However, the command line
interface options do not offer a way exactly declare exchanges, queues,
and bindings (durability options, arbitrary arguments, etc) so the
documentation is updated to indicate for complex queue configurations,
the configuration file should be used instead of command-line arguments.