### PR TITLE
Ensure CLI tests don't depend on each other

### DIFF
--- a/fedora_messaging/config.py
+++ b/fedora_messaging/config.py
@@ -225,6 +225,7 @@ meaning there is no limit. The default settings are::
 """
 from __future__ import unicode_literals
 
+import copy
 import logging
 import logging.config
 import os
@@ -454,7 +455,7 @@ class LazyConfig(dict):
         Otherwise, the path defaults to ``/etc/fedora-messaging/config.toml``.
         """
         self.loaded = True
-        config = DEFAULTS.copy()
+        config = copy.deepcopy(DEFAULTS)
 
         if config_path is None:
             if "FEDORA_MESSAGING_CONF" in os.environ:

--- a/fedora_messaging/tests/unit/test_config.py
+++ b/fedora_messaging/tests/unit/test_config.py
@@ -190,6 +190,14 @@ class ValidateQueuesTests(unittest.TestCase):
 class LoadTests(unittest.TestCase):
     """Unit tests for :func:`fedora_messaging.config.load`."""
 
+    def test_deep_copy(self):
+        """Assert nested dictionaries in DEFAULTS are not copied into the config instance."""
+        config = msg_config.LazyConfig().load_config()
+
+        config["queues"]["somequeue"] = {}
+
+        self.assertNotIn("somequeue", msg_config.DEFAULTS["queues"])
+
     @mock.patch("fedora_messaging.config._log", autospec=True)
     @mock.patch("fedora_messaging.config.os.path.exists", return_value=False)
     def test_missing_config_file(self, mock_exists, mock_log):


### PR DESCRIPTION
The CLI test suite failed to reset the configuration after each test so some tests ran with different configurations. Fix up all those tests and make sure each test gets a fresh default config.