### PR TITLE
Make the message body a public property

### DIFF
--- a/docs/sample_schema_package/mailman_schema/schema.py
+++ b/docs/sample_schema_package/mailman_schema/schema.py
@@ -130,21 +130,21 @@ class MessageV1(BaseMessage):
     @property
     def subject(self):
         """The email's subject."""
-        return self._body["msg"]["subject"]
+        return self.body["msg"]["subject"]
 
     @property
     def body(self):
         """The email message body."""
-        return self._body["msg"]["body"]
+        return self.body["msg"]["body"]
 
     @property
     def agent_avatar(self):
         """An URL to the avatar of the user who caused the action."""
-        from_header = self._body["msg"]["from"]
+        from_header = self.body["msg"]["from"]
         return get_avatar(from_header)
 
     def _get_archived_at(self):
-        return self._body["msg"]["archived-at"]
+        return self.body["msg"]["archived-at"]
 
 
 class MessageV2(BaseMessage):
@@ -184,18 +184,18 @@ class MessageV2(BaseMessage):
     @property
     def subject(self):
         """The email's subject."""
-        return self._body["subject"]
+        return self.body["subject"]
 
     @property
     def body(self):
         """The email message body."""
-        return self._body["body"]
+        return self.body["body"]
 
     @property
     def agent_avatar(self):
         """An URL to the avatar of the user who caused the action."""
-        from_header = self._body["from"]
+        from_header = self.body["from"]
         return get_avatar(from_header)
 
     def _get_archived_at(self):
-        return self._body["archived-at"]
+        return self.body["archived-at"]

--- a/docs/tutorial/schemas.rst
+++ b/docs/tutorial/schemas.rst
@@ -121,7 +121,7 @@ from the message, or to create a human-readable representation.
 Change the ``__str__()`` method to use the expected items from the message body. For example::
 
     return '{owner} did something to the {package} package'.format(
-        owner=self._body['owner'], package=self._body['package']['name'])
+        owner=self.body['owner'], package=self.body['package']['name'])
 
 Also edit the ``summary`` property to return something relevant.
 

--- a/fedora_messaging/message.py
+++ b/fedora_messaging/message.py
@@ -27,6 +27,7 @@ this class in a small Python package of its own.
 import datetime
 import json
 import logging
+import warnings
 import uuid
 
 import jsonschema
@@ -383,7 +384,7 @@ class Message(object):
     def __init__(
         self, body=None, headers=None, topic=None, properties=None, severity=None
     ):
-        self._body = body or {}
+        self.body = body or {}
         if topic:
             self.topic = topic
         headers = headers or {}
@@ -459,14 +460,14 @@ class Message(object):
     @property
     def _encoded_body(self):
         """The encoded body used to publish the message."""
-        return json.dumps(self._body).encode("utf-8")
+        return json.dumps(self.body).encode("utf-8")
 
     def __repr__(self):
         """
         Provide a printable representation of the object that can be passed to func:`eval`.
         """
         return "{}(id={}, topic={}, body={})".format(
-            self.__class__.__name__, repr(self.id), repr(self.topic), repr(self._body)
+            self.__class__.__name__, repr(self.id), repr(self.topic), repr(self.body)
         )
 
     def __eq__(self, other):
@@ -498,7 +499,7 @@ class Message(object):
 
         return (
             self.topic == other.topic
-            and self._body == other._body
+            and self.body == other.body
             and headers == other_headers
         )
 
@@ -527,9 +528,9 @@ class Message(object):
             jsonschema.validate(self._headers, schema)
         for schema in (self.body_schema, Message.body_schema):
             _log.debug(
-                'Validating message body "%r" with schema "%r"', self._body, schema
+                'Validating message body "%r" with schema "%r"', self.body, schema
             )
-            jsonschema.validate(self._body, schema)
+            jsonschema.validate(self.body, schema)
 
     @property
     def summary(self):
@@ -559,7 +560,7 @@ class Message(object):
             h=json.dumps(
                 self._headers, sort_keys=True, indent=4, separators=(",", ": ")
             ),
-            b=json.dumps(self._body, sort_keys=True, indent=4, separators=(",", ": ")),
+            b=json.dumps(self.body, sort_keys=True, indent=4, separators=(",", ": ")),
         )
 
     @property
@@ -646,6 +647,24 @@ class Message(object):
             "topic": self.topic,
             "headers": self._headers,
             "id": self.id,
-            "body": self._body,
+            "body": self.body,
             "queue": self.queue,
         }
+
+    @property
+    def _body(self):
+        warnings.warn(
+            "The '_body' property has been renamed to 'body'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.body
+
+    @_body.setter
+    def _body(self, value):
+        warnings.warn(
+            "The '_body' property has been renamed to 'body'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.body = value

--- a/fedora_messaging/tests/integration/test_publish_consume.py
+++ b/fedora_messaging/tests/integration/test_publish_consume.py
@@ -127,7 +127,7 @@ def test_basic_pub_sub():
     assert len(messages_received) == 3
     for m in messages_received:
         assert u"nice.message" == m.topic
-        assert {u"encouragement": u"You're doing great!"} == m._body
+        assert {u"encouragement": u"You're doing great!"} == m.body
         assert "sent-at" in m._headers
         del m._headers["sent-at"]
         assert expected_headers == m._headers

--- a/fedora_messaging/tests/unit/test_message.py
+++ b/fedora_messaging/tests/unit/test_message.py
@@ -115,7 +115,7 @@ class MessageLoadsTests(unittest.TestCase):
         self.assertIsInstance(test_message, message.Message)
         self.assertEqual("test topic", test_message.topic)
         self.assertEqual("test id", test_message.id)
-        self.assertEqual({"test_key": "test_value"}, test_message._body)
+        self.assertEqual({"test_key": "test_value"}, test_message.body)
         self.assertEqual("test queue", test_message.queue)
         self.assertEqual(
             message.WARNING, test_message._headers["fedora_messaging_severity"]
@@ -190,7 +190,7 @@ class MessageLoadsTests(unittest.TestCase):
         self.assertEqual(len(messages), 1)
         self.assertEqual("test topic", test_message.topic)
         self.assertEqual("test id", test_message.id)
-        self.assertEqual({"test_key": "test_value"}, test_message._body)
+        self.assertEqual({"test_key": "test_value"}, test_message.body)
         self.assertEqual(None, test_message.queue)
         self.assertEqual(
             message.WARNING, test_message._headers["fedora_messaging_severity"]
@@ -430,21 +430,21 @@ class CustomMessage(message.Message):
     @property
     def usernames(self):
         try:
-            return self._body["users"]
+            return self.body["users"]
         except KeyError:
             return []
 
     @property
     def packages(self):
         try:
-            return self._body["packages"]
+            return self.body["packages"]
         except KeyError:
             return []
 
     @property
     def containers(self):
         try:
-            return self._body["containers"]
+            return self.body["containers"]
         except KeyError:
             return []
         pass
@@ -452,14 +452,14 @@ class CustomMessage(message.Message):
     @property
     def modules(self):
         try:
-            return self._body["modules"]
+            return self.body["modules"]
         except KeyError:
             return []
 
     @property
     def flatpaks(self):
         try:
-            return self._body["flatpaks"]
+            return self.body["flatpaks"]
         except KeyError:
             return []
 

--- a/fedora_messaging/tests/unit/test_message.py
+++ b/fedora_messaging/tests/unit/test_message.py
@@ -423,6 +423,30 @@ class MessageTests(unittest.TestCase):
         test_msg_dict = test_msg._dump()
         self.assertEqual(expected_dict, test_msg_dict)
 
+    @mock.patch("fedora_messaging.message.warnings")
+    def test_body_deprecation_setter(self, mock_warning):
+        """Assert a deprecation warning is printed on _body setter usage."""
+        m = message.Message(body={})
+        m._body["old"] = "interface"
+
+        mock_warning.warn.assert_called_once_with(
+            "The '_body' property has been renamed to 'body'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    @mock.patch("fedora_messaging.message.warnings")
+    def test_body_deprecation_getter(self, mock_warning):
+        """Assert a deprecation warning is printed on _body getter usage."""
+        m = message.Message(body={"old": "interface"})
+        self.assertEqual(m._body["old"], "interface")
+
+        mock_warning.warn.assert_called_once_with(
+            "The '_body' property has been renamed to 'body'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
 
 class CustomMessage(message.Message):
     """Test class that returns values for filter properties."""

--- a/fedora_messaging/tests/unit/test_session.py
+++ b/fedora_messaging/tests/unit/test_session.py
@@ -49,7 +49,7 @@ class PublisherSessionTests(unittest.TestCase):
         self.message._headers = {}
         self.message.topic = "test.topic"
         self.message._encoded_routing_key = b"test.topic"
-        self.message._body = "test body"
+        self.message.body = "test body"
         self.message._encoded_body = b'"test body"'
         self.tls_conf = {
             "keyfile": None,
@@ -777,7 +777,7 @@ class ConsumerSessionMessageTests(unittest.TestCase):
         msg = self.consumer._consumer_callback.call_args_list[0][0][0]
         msg.validate.assert_called_once()
         self.channel.basic_ack.assert_called_with(delivery_tag="testtag")
-        self.assertEqual(msg._body, "test body")
+        self.assertEqual(msg.body, "test body")
 
     def test_message_queue_set(self):
         """Assert the queue attribute is set on messages."""
@@ -791,7 +791,7 @@ class ConsumerSessionMessageTests(unittest.TestCase):
         self.consumer._on_message(self.channel, self.frame, self.properties, body)
         self.consumer._consumer_callback.assert_called_once()
         msg = self.consumer._consumer_callback.call_args_list[0][0][0]
-        self.assertEqual(msg._body, "test body unicode é à ç")
+        self.assertEqual(msg.body, "test body unicode é à ç")
 
     def test_message_wrong_encoding(self):
         body = '"test body unicode é à ç"'.encode("utf-8")

--- a/news/PR119.api
+++ b/news/PR119.api
@@ -1,0 +1,1 @@
+The :py:attr:`Message._body` attribute is renamed to ``body``, and is now part of the public API.


### PR DESCRIPTION
The message `body` property should be public, otherwise schema writers will have to write an accessor for each dictionary entry, which does not make much sense.