### PR TITLE
Fix the mailman_schema example to work with Message.body

### DIFF
--- a/docs/sample_schema_package/mailman_schema/schema.py
+++ b/docs/sample_schema_package/mailman_schema/schema.py
@@ -29,7 +29,9 @@ class BaseMessage(message.Message):
 
     def __str__(self):
         """Return a complete human-readable representation of the message."""
-        return "Subject: {subj}\n{body}\n".format(subj=self.subject, body=self.body)
+        return "Subject: {subj}\n{body}\n".format(
+            subj=self.subject, body=self.email_body
+        )
 
     @property
     def summary(self):
@@ -42,9 +44,9 @@ class BaseMessage(message.Message):
         return 'Message did not implement "subject" property'
 
     @property
-    def body(self):
+    def email_body(self):
         """The email message body."""
-        return 'Message did not implement "body" property'
+        return 'Message did not implement "email_body" property'
 
     @property
     def url(self):
@@ -133,7 +135,7 @@ class MessageV1(BaseMessage):
         return self.body["msg"]["subject"]
 
     @property
-    def body(self):
+    def email_body(self):
         """The email message body."""
         return self.body["msg"]["body"]
 
@@ -187,7 +189,7 @@ class MessageV2(BaseMessage):
         return self.body["subject"]
 
     @property
-    def body(self):
+    def email_body(self):
         """The email message body."""
         return self.body["body"]
 

--- a/docs/sample_schema_package/mailman_schema/tests/test_schema.py
+++ b/docs/sample_schema_package/mailman_schema/tests/test_schema.py
@@ -100,7 +100,7 @@ class MessageV1Tests(unittest.TestCase):
         """Assert the message provides a "body" attribute."""
         message = self.msg_class(body=self.full_message)
 
-        self.assertEqual("hello world", message.body)
+        self.assertEqual("hello world", message.email_body)
 
     def test_url(self):
         """Assert the message provides a "url" attribute."""


### PR DESCRIPTION
The message ``body`` variable is used by the Message class, but the
example schema is still defining a property using that name.

See https://pagure.io/fedora-commops/fedora-happiness-packets/issue/96

Signed-off-by: Jeremy Cline <jcline@redhat.com>