### PR TITLE
Add Twisted consume APIs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ coverage
 sphinx
 mock
 twisted
+treq
 pytest<=4.0
 pytest-twisted
 pyOpenSSL

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,6 +23,11 @@ Publishing
 Subscribing
 ===========
 
+.. autofunction:: fedora_messaging.api.twisted_consume
+
+.. autoclass:: fedora_messaging.api.Consumer
+   :members:
+
 .. autofunction:: fedora_messaging.api.consume
 
 
@@ -85,6 +90,8 @@ Twisted
 
 In addition to the synchronous API, a Twisted API is provided for applications
 that need an asynchronous API. This API requires Twisted 16.1.0 or greater.
+
+.. note:: This API is deprecated, please use :class:`fedora_messaging.api.twisted_consume`
 
 Protocol
 --------

--- a/docs/fedora-messaging.rst
+++ b/docs/fedora-messaging.rst
@@ -95,6 +95,63 @@ configuration file and no options on the command line.
     in *all* ``bindings`` entries in the configuration file.
 
 
+Exit codes
+==========
+
+consume
+-------
+The ``consume`` command can exit for a number of reasons:
+
+``0``
+
+    The consumer intentionally halted by raising a ``HaltConsumer`` exception.
+
+``2``
+
+    The argument or option provided is invalid.
+
+``10``
+
+    The consumer was unable to declare an exchange, queue, or binding in the
+    message broker. This occurs with the user does not have permission on the
+    broker to create the object *or* the object already exists, but does not
+    have the attributes the consumer expects (e.g. the consumer expects it to
+    be a durable queue, but it is transient).
+
+``11``
+
+    The consumer encounters an unexpected error while registering the consumer
+    with the broker. This is a bug in fedora-messaging and should be reported.
+
+``12``
+
+    The consumer is canceled by the message broker.  The consumer is typically
+    canceled when the queue it is subscribed to is deleted on the broker, but
+    other exceptional cases could result in this. The broker administrators
+    should be consulted in this case.
+
+``13``
+
+    An unexpected general exception is raised by your consumer callback.
+
+Additionally, consumer callbacks can cause the command to exit with a custom
+exit code. Consult the consumer's documentation to see what error codes it uses.
+
+
+Signals
+=======
+
+consume
+-------
+
+The ``consume`` command handles the SIGTERM and SIGINT signals by allowing any
+consumers which are currently processing a message to finish, acknowledging the
+message to the message broker, and then shutting down. Repeated SIGTERM or
+SIGINT signals are ignored. To halt immediately, send the SIGKILL signal;
+messages that are partially processed will be re-delivered when the consumer
+restarts.
+
+
 Systemd service
 ===============
 

--- a/fedora_messaging/exceptions.py
+++ b/fedora_messaging/exceptions.py
@@ -76,6 +76,15 @@ class ConsumeException(BaseException):
     """Base class for exceptions related to consuming."""
 
 
+class ConsumerCanceled(ConsumeException):
+    """
+    Raised when the server has canceled the consumer.
+
+    This can happen when the queue the consumer is subscribed to is deleted,
+    or when the node the queue is located on fails.
+    """
+
+
 class Nack(ConsumeException):
     """
     Consumer callbacks should raise this to indicate they wish the message they

--- a/fedora_messaging/tests/integration/test_cli.py
+++ b/fedora_messaging/tests/integration/test_cli.py
@@ -1,0 +1,88 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Tests for the ``fedora-messaging`` command-line interface."""
+import os
+import subprocess
+import time
+import uuid
+
+import pytest
+import requests
+
+from fedora_messaging import api, exceptions, message
+
+
+FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../fixtures/"))
+CLI_CONF = os.path.join(FIXTURES_DIR, "cli_integration.toml")
+
+
+def halt_exit_0(message):
+    """Exit with code 0 when it gets a message"""
+    raise exceptions.HaltConsumer()
+
+
+def halt_exit_42(message):
+    """Exit with code 42 when it gets a message"""
+    raise exceptions.HaltConsumer(
+        exit_code=42, reason="Life, the universe, and everything"
+    )
+
+
+@pytest.fixture
+def queue(scope="function"):
+    queue = str(uuid.uuid4())
+    yield queue
+    requests.delete(
+        "http://localhost:15672/api/queues/%2F/" + queue,
+        auth=("guest", "guest"),
+        timeout=3,
+    )
+
+
+@pytest.mark.parametrize(
+    "callback,exit_code,msg",
+    [
+        ("halt_exit_0", 0, b"Consumer indicated it wishes consumption to halt"),
+        ("halt_exit_42", 42, b"Life, the universe, and everything"),
+    ],
+)
+def test_consume_halt_with_exitcode(callback, exit_code, msg, queue):
+    """Assert user execution halt with reason and exit_code is reported."""
+    args = [
+        "fedora-messaging",
+        "--conf={}".format(CLI_CONF),
+        "consume",
+        "--callback=fedora_messaging.tests.integration.test_cli:{}".format(callback),
+        "--queue-name={}".format(queue),
+        "--exchange=amq.topic",
+        "--routing-key=#",
+    ]
+
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(5)
+
+    api.publish(message.Message())
+    for _ in range(5):
+        time.sleep(1)
+        if process.poll() is not None:
+            break
+    else:
+        process.kill()
+        pytest.fail("Process never stopped!: {}".format(process.stdout.read()))
+
+    assert process.returncode == exit_code
+    assert msg in process.stdout.read()

--- a/fedora_messaging/tests/integration/test_twisted_api.py
+++ b/fedora_messaging/tests/integration/test_twisted_api.py
@@ -1,0 +1,586 @@
+"""Test the Twisted consume APIs on a real broker running on localhost."""
+
+import uuid
+import six
+import mock
+import time
+
+from twisted.internet import reactor, defer, task
+import treq
+import pytest
+import pytest_twisted
+
+from fedora_messaging import api, message, exceptions, config
+from fedora_messaging.twisted.protocol import _add_timeout
+
+
+HTTP_API = "http://localhost:15672/api/"
+HTTP_AUTH = ("guest", "guest")
+
+
+def setup_function(function):
+    """Ensure each test starts with a fresh Service and configuration."""
+    config.conf = config.LazyConfig()
+    config.conf["client_properties"]["app"] = function.__name__
+    if api._twisted_service:
+        pytest_twisted.blockon(api._twisted_service.stopService())
+    api._twisted_service = None
+
+
+@pytest.fixture
+def admin_user():
+    """
+    Fixture that creates a random admin user and deletes the user afterwards.
+
+    Useful if the test wishes to alter permissions to test failure cases. Default
+    permissions is complete access to the "/" vhost.
+
+    Returns:
+        The username of the new administrator. The password is "guest".
+    """
+    # Create a user with no permissions
+    username = str(uuid.uuid4())
+    url = "{base}users/{user}".format(base=HTTP_API, user=username)
+    body = {"username": username, "password": "guest", "tags": "administrator"}
+    deferred_resp = treq.put(url, json=body, auth=HTTP_AUTH, timeout=3)
+
+    @pytest_twisted.inlineCallbacks
+    def cp(resp):
+        assert resp.code == 201
+        url = "{base}permissions/%2F/{user}".format(base=HTTP_API, user=username)
+        body = {"configure": ".*", "write": ".*", "read": ".*"}
+        resp = yield treq.put(url, json=body, auth=HTTP_AUTH, timeout=3)
+        assert resp.code == 201
+
+    deferred_resp.addCallbacks(cp, cp)
+    pytest_twisted.blockon(deferred_resp)
+    yield username
+
+    # Cleanup
+    deferred_resp = treq.delete(url, auth=HTTP_AUTH, timeout=3)
+    pytest_twisted.blockon(deferred_resp)
+
+
+@pytest_twisted.inlineCallbacks
+def get_queue(name, delay=10):
+    """
+    Retrieve data about a queue in the broker in the default vhost ("/").
+
+    Args:
+        delay: Time to wait before querying the server. It can take some time for
+            everything to settle and become available in the HTTP API. 10 seconds
+            was arrived at after intermittent failures at lower values.
+
+    Returns:
+        dict: A dictionary representation of the queue.
+    """
+    # Assert both messages are delivered, no messages are un-acked, and only one
+    # message got a positive acknowledgment.
+    url = "{base}queues/%2F/{queue}".format(base=HTTP_API, queue=name)
+    server_queue = yield task.deferLater(
+        reactor, delay, treq.get, url, auth=HTTP_AUTH, timeout=3
+    )
+    server_queue = yield server_queue.json()
+    defer.returnValue(server_queue)
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_halt_consumer():
+    """
+    Assert raising HaltConsumer works with :func:`fedora_messaging.api.twisted_consume`
+    API.
+    """
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+    msg = message.Message(
+        topic=u"nice.message",
+        headers={u"niceness": u"very"},
+        body={u"encouragement": u"You're doing great!"},
+    )
+    expected_headers = {
+        u"fedora_messaging_severity": 20,
+        u"fedora_messaging_schema": u"base.message",
+        u"niceness": u"very",
+    }
+    messages_received = []
+
+    def callback(message):
+        """Count to 3 and quit."""
+        messages_received.append(message)
+        if len(messages_received) == 3:
+            raise exceptions.HaltConsumer()
+
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+
+    # Assert the server reports a consumer
+    server_queue = yield get_queue(queue)
+    assert server_queue["consumers"] == 1
+
+    for _ in range(0, 3):
+        api.publish(msg, "amq.topic")
+
+    _add_timeout(consumers[0].result, 10)
+    try:
+        yield consumers[0].result
+    except exceptions.HaltConsumer as e:
+        assert len(messages_received) == 3
+        assert e.exit_code == 0
+        for m in messages_received:
+            assert u"nice.message" == m.topic
+            assert {u"encouragement": u"You're doing great!"} == m.body
+            assert "sent-at" in m._headers
+            del m._headers["sent-at"]
+            assert expected_headers == m._headers
+        server_queue = yield get_queue(queue)
+        assert server_queue["consumers"] == 0
+    except (defer.TimeoutError, defer.CancelledError):
+        yield consumers[0].cancel()
+        pytest.fail("Timeout reached without consumer halting!")
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_stop_service():
+    """
+    Assert stopping the service, which happens when the reactor shuts down, waits
+    for consumers to finish processing and then cancels them before closing the connection.
+    """
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+    message_received, message_processed = defer.Deferred(), defer.Deferred()
+
+    def callback(message):
+        """Callback when the message is received, introduce a delay, then callback again."""
+        reactor.callFromThread(message_received.callback, None)
+        time.sleep(5)
+        reactor.callFromThread(message_processed.callback, None)
+
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+    api.publish(message.Message(), "amq.topic")
+
+    _add_timeout(consumers[0].result, 10)
+    _add_timeout(message_received, 10)
+    try:
+        yield message_received
+    except (defer.TimeoutError, defer.CancelledError):
+        yield consumers[0].cancel()
+        pytest.fail("Timeout reached without consumer receiving message!")
+
+    assert not message_processed.called
+    deferred_stop = api._twisted_service.stopService()
+
+    _add_timeout(message_processed, 10)
+    try:
+        yield message_processed
+        # The request to stop should wait on the message to be processed
+        assert deferred_stop.called is False
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without consumer processing message")
+    yield deferred_stop
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_cancel():
+    """Assert canceling works with :func:`fedora_messaging.api.twisted_consume` API."""
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+
+    # Assert that the number of consumers we think we started is the number the
+    # server things we started. This will fail if other tests don't clean up properly.
+    # If it becomes problematic perhaps each test should have a vhost.
+    consumers = yield api.twisted_consume(lambda m: m, bindings, queues)
+    consumers[0].result.addErrback(pytest.fail)
+
+    server_queue = yield get_queue(queue)
+    assert server_queue["consumers"] == 1
+
+    try:
+        d = consumers[0].cancel()
+        _add_timeout(d, 5)
+        yield d
+
+        # Assert the consumer.result deferred has called back when the cancel
+        # deferred fires.
+        assert consumers[0].result.called
+
+        # Finally make sure the server agrees that the consumer is canceled.
+        server_queue = yield get_queue(queue)
+        assert server_queue["consumers"] == 0
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without consumer halting!")
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_halt_consumer_requeue():
+    """Assert raising HaltConsumer with requeue=True re-queues the message."""
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+    msg = message.Message(
+        topic=u"nice.message",
+        headers={u"niceness": u"very"},
+        body={u"encouragement": u"You're doing great!"},
+    )
+
+    def callback(message):
+        """Count to 3 and quit."""
+        raise exceptions.HaltConsumer(exit_code=1, requeue=True)
+
+    # Assert that the number of consumers we think we started is the number the
+    # server things we started. This will fail if other tests don't clean up properly.
+    # If it becomes problematic perhaps each test should have a vhost.
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+    api.publish(msg, "amq.topic")
+
+    _add_timeout(consumers[0].result, 10)
+    try:
+        yield consumers[0].result
+    except exceptions.HaltConsumer as e:
+        # Assert there are no consumers for the queue, and that there's a ready message
+        assert e.exit_code == 1
+
+        server_queue = yield get_queue(queue)
+        assert server_queue["consumers"] == 0
+        assert server_queue["messages_ready"] == 1
+    except (defer.TimeoutError, defer.CancelledError):
+        yield consumers[0].cancel()
+        pytest.fail("Timeout reached without consumer halting!")
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_drop_message():
+    """Assert raising Drop causes the message to be dropped, but processing continues."""
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+    msg = message.Message(
+        topic=u"nice.message",
+        headers={u"niceness": u"very"},
+        body={u"encouragement": u"You're doing great!"},
+    )
+    dropped_messages = []
+
+    def callback(message):
+        """Drop 1 message and then halt on the second message."""
+        dropped_messages.append(message)
+        if len(dropped_messages) == 2:
+            raise exceptions.HaltConsumer()
+        raise exceptions.Drop()
+
+    # Assert that the number of consumers we think we started is the number the
+    # server things we started. This will fail if other tests don't clean up properly.
+    # If it becomes problematic perhaps each test should have a vhost.
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+    api.publish(msg, "amq.topic")
+    api.publish(msg, "amq.topic")
+
+    _add_timeout(consumers[0].result, 10)
+    try:
+        yield consumers[0].result
+    except exceptions.HaltConsumer:
+        # Assert both messages are delivered, no messages are un-acked, and only one
+        # message got a positive acknowledgment.
+        server_queue = yield task.deferLater(
+            reactor,
+            5,
+            treq.get,
+            HTTP_API + "queues/%2F/" + queue,
+            auth=HTTP_AUTH,
+            timeout=3,
+        )
+        server_queue = yield server_queue.json()
+        assert server_queue["consumers"] == 0
+        assert server_queue["messages"] == 0
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without consumer halting!")
+    finally:
+        yield consumers[0].cancel()
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_nack_message():
+    """Assert raising Nack causes the message to be replaced in the queue."""
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+    msg = message.Message(
+        topic=u"nice.message",
+        headers={u"niceness": u"very"},
+        body={u"encouragement": u"You're doing great!"},
+    )
+    nacked_messages = []
+
+    def callback(message):
+        """Nack the message, then halt."""
+        nacked_messages.append(message)
+        if len(nacked_messages) == 2:
+            raise exceptions.HaltConsumer()
+        raise exceptions.Nack()
+
+    # Assert that the number of consumers we think we started is the number the
+    # server things we started. This will fail if other tests don't clean up properly.
+    # If it becomes problematic perhaps each test should have a vhost.
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+    api.publish(msg, "amq.topic")
+
+    _add_timeout(consumers[0].result, 10)
+    try:
+        yield consumers[0].result
+    except exceptions.HaltConsumer:
+        # Assert the message was delivered, redelivered when Nacked, then acked by HaltConsumer
+        server_queue = yield task.deferLater(
+            reactor,
+            5,
+            treq.get,
+            HTTP_API + "queues/%2F/" + queue,
+            auth=HTTP_AUTH,
+            timeout=3,
+        )
+        server_queue = yield server_queue.json()
+        assert server_queue["consumers"] == 0
+        assert server_queue["messages"] == 0
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without consumer halting!")
+    finally:
+        yield consumers[0].cancel()
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_general_exception():
+    """
+    Assert if the callback raises an unhandled exception, it is passed on to the
+    consumer.result and the message is re-queued.
+    """
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+    msg = message.Message(
+        topic=u"nice.message",
+        headers={u"niceness": u"very"},
+        body={u"encouragement": u"You're doing great!"},
+    )
+
+    def callback(message):
+        """An *exceptionally* useless callback"""
+        raise Exception("Oh the huge manatee")
+
+    # Assert that the number of consumers we think we started is the number the
+    # server things we started. This will fail if other tests don't clean up properly.
+    # If it becomes problematic perhaps each test should have a vhost.
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+    api.publish(msg, "amq.topic")
+
+    _add_timeout(consumers[0].result, 10)
+    try:
+        yield consumers[0].result
+        pytest.fail("Expected an exception to be raised.")
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without consumer halting!")
+    except Exception as e:
+        # Assert the message was delivered and re-queued when the consumer crashed.
+        assert e.args[0] == "Oh the huge manatee"
+        server_queue = yield task.deferLater(
+            reactor,
+            10,
+            treq.get,
+            HTTP_API + "queues/%2F/" + queue,
+            auth=HTTP_AUTH,
+            timeout=3,
+        )
+        server_queue = yield server_queue.json()
+        assert server_queue["consumers"] == 0
+        assert server_queue["messages"] == 1
+    finally:
+        yield consumers[0].cancel()
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_connection_reset():
+    """
+    Assert consuming works across connections and handles connection resets.
+
+    This test sets up a queue, publishes 2 messages to itself, then kills all active
+    connections on the broker. It then sends a third message and asserts the consumer
+    gets it.
+    """
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+    msg = message.Message(
+        topic=u"nice.message",
+        headers={u"niceness": u"very"},
+        body={u"encouragement": u"You're doing great!"},
+    )
+    messages_received = []
+    two_received = defer.Deferred()  # Fired by the callback on 2 messages
+
+    def callback(message):
+        """Count to, 2, fire a deferred, then count to 3 and quit."""
+        messages_received.append(message)
+        if len(messages_received) == 2:
+            two_received.callback(None)
+        if len(messages_received) == 3:
+            raise exceptions.HaltConsumer()
+
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+
+    # Wait for two messages to get through, kill the connection, and then send
+    # the third and wait for the consumer to finish
+    api.publish(msg, "amq.topic")
+    api.publish(msg, "amq.topic")
+    _add_timeout(two_received, 10)
+    try:
+        yield two_received
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without receiving first two messages")
+
+    for _ in range(10):
+        conns = yield task.deferLater(
+            reactor, 1, treq.get, HTTP_API + "connections", auth=HTTP_AUTH, timeout=3
+        )
+        conns = yield conns.json()
+        this_conn = [
+            c
+            for c in conns
+            if c["client_properties"]["app"] == "test_twisted_consume_connection_reset"
+        ]
+        if this_conn:
+            cname = six.moves.urllib.parse.quote(this_conn[0]["name"])
+            yield treq.delete(
+                HTTP_API + "connections/" + cname, auth=HTTP_AUTH, timeout=3
+            )
+            break
+    else:
+        pytest.fail("Unable to find and kill connection!")
+
+    # The consumer should receive this third message after restarting its connection
+    # and then it should exit gracefully.
+    api.publish(msg, "amq.topic")
+    _add_timeout(consumers[0].result, 10)
+    try:
+        yield consumers[0].result
+    except exceptions.HaltConsumer:
+        assert len(messages_received) == 3
+    except (defer.TimeoutError, defer.CancelledError):
+        yield consumers[0].cancel()
+        pytest.fail("Timeout reached without consumer halting!")
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_serverside_cancel():
+    """
+    Assert the consumer halts and ``consumer.result`` errbacks when the server
+    explicitly cancels the consumer (by deleting the queue).
+    """
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+
+    consumers = yield api.twisted_consume(lambda x: x, bindings, queues)
+
+    # Delete the queue and assert the consumer errbacks
+    url = "{base}queues/%2F/{queue}".format(base=HTTP_API, queue=queue)
+    yield treq.delete(url, auth=HTTP_AUTH, timeout=3)
+
+    _add_timeout(consumers[0].result, 10)
+    try:
+        yield consumers[0].result
+        pytest.fail("Consumer did not errback!")
+    except exceptions.ConsumerCanceled:
+        pass
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without consumer calling its errback!")
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_permission_denied(admin_user):
+    """
+    Assert the call to api.twisted_consume errbacks on permissions errors
+    """
+    url = "{base}permissions/%2F/{user}".format(base=HTTP_API, user=admin_user)
+    body = {"configure": ".*", "write": "", "read": ""}
+    resp = yield treq.put(url, json=body, auth=HTTP_AUTH, timeout=3)
+    assert resp.code == 204
+
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+
+    amqp_url = "amqp://{user}:guest@localhost:5672/%2F".format(user=admin_user)
+    try:
+        with mock.patch.dict(config.conf, {"amqp_url": amqp_url}):
+            yield api.twisted_consume(lambda x: x, bindings, queues)
+        pytest.fail("Call failed to raise an exception")
+    except exceptions.BadDeclaration as e:
+        assert e.reason.args[0] == 403
+        assert e.reason.args[1] == (
+            "ACCESS_REFUSED - access to queue '{}' in vhost '/' refused for user"
+            " '{}'".format(queue, admin_user)
+        )
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_invalid_message():
+    """Assert messages that fail validation are nacked."""
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [
+        {
+            "queue": queue,
+            "exchange": "amq.topic",
+            "routing_keys": ["test_twisted_invalid_message"],
+        }
+    ]
+
+    consumers = yield api.twisted_consume(
+        lambda x: pytest.fail("Message should be nacked"), bindings, queues
+    )
+
+    url = HTTP_API + "exchanges/%2F/amq.topic/publish"
+    body = {
+        "properties": {},
+        "routing_key": "test_twisted_invalid_message",
+        "payload": "not json",
+        "payload_encoding": "string",
+    }
+    response = yield treq.post(url, json=body, auth=HTTP_AUTH, timeout=3)
+    response = yield response.json()
+    assert response["routed"] is True
+    yield consumers[0].cancel()
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_update_callback():
+    """Assert a second call to consume updates an existing callback."""
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+    bindings = [{"queue": queue, "exchange": "amq.topic", "routing_keys": ["#"]}]
+
+    callback1 = defer.Deferred()
+    callback2 = defer.Deferred()
+
+    consumers1 = yield api.twisted_consume(
+        lambda m: reactor.callFromThread(callback1.callback, m), bindings, queues
+    )
+    api.publish(message.Message(), "amq.topic")
+    _add_timeout(callback1, 10)
+    try:
+        yield callback1
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Never received message for initial callback")
+
+    consumers2 = yield api.twisted_consume(
+        lambda m: reactor.callFromThread(callback2.callback, m), bindings, queues
+    )
+    api.publish(message.Message(), "amq.topic")
+    _add_timeout(callback2, 10)
+    try:
+        yield callback2
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Never received message for updated callback")
+
+    assert consumers1[0]._tag == consumers2[0]._tag
+
+    yield consumers2[0].cancel()

--- a/fedora_messaging/tests/unit/twisted/test_factory.py
+++ b/fedora_messaging/tests/unit/twisted/test_factory.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import logging
 import unittest
 
 import mock
@@ -48,9 +49,11 @@ class FactoryTests(unittest.TestCase):
 
     def test_started_connection(self):
         """Assert connection attempts are logged."""
-        with mock.patch("fedora_messaging.twisted.factory._log") as mock_log:
+        with mock.patch(
+            "fedora_messaging.twisted.factory._legacy_twisted_log"
+        ) as mock_log:
             self.factory.startedConnecting(None)
-        mock_log.info.assert_called_once_with(
+        mock_log.msg.assert_called_once_with(
             "Started new connection to the AMQP broker"
         )
 
@@ -193,10 +196,14 @@ class FactoryTests(unittest.TestCase):
     )
     def test_connection_failed(self):
         """Assert when the connection fails it is logged."""
-        with mock.patch("fedora_messaging.twisted.factory._log") as mock_log:
+        with mock.patch(
+            "fedora_messaging.twisted.factory._legacy_twisted_log"
+        ) as mock_log:
             self.factory.clientConnectionFailed(None, mock.Mock(value="something"))
-        mock_log.warn.assert_called_once_with(
-            "Connection to the AMQP broker failed ({reason})", reason="something"
+        mock_log.msg.assert_called_once_with(
+            "Connection to the AMQP broker failed ({reason})",
+            reason="something",
+            logLevel=logging.WARNING,
         )
 
     def test_stopTrying(self):

--- a/fedora_messaging/tests/unit/twisted/test_service.py
+++ b/fedora_messaging/tests/unit/twisted/test_service.py
@@ -29,6 +29,7 @@ from fedora_messaging import config
 from fedora_messaging.twisted.factory import FedoraMessagingFactory
 from fedora_messaging.twisted.service import (
     FedoraMessagingService,
+    FedoraMessagingServiceV2,
     _ssl_context_factory,
 )
 from fedora_messaging.tests import FIXTURES_DIR
@@ -114,6 +115,15 @@ class ServiceTests(unittest.TestCase):
         with mock.patch(ss_path) as stopService:
             service.stopService()
             stopService.assert_not_called()
+
+
+class ServiceV2Tests(unittest.TestCase):
+    def test_init_tls(self):
+        """Assert creating the service with an amqps URL configures TLS."""
+        service = FedoraMessagingServiceV2("amqps://")
+
+        self.assertTrue(isinstance(service._parameters, pika.URLParameters))
+        self.assertIsNotNone(service._parameters.ssl_options)
 
 
 class SslContextFactoryTests(unittest.TestCase):

--- a/fedora_messaging/twisted/consumer.py
+++ b/fedora_messaging/twisted/consumer.py
@@ -1,0 +1,103 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+from __future__ import absolute_import
+
+import uuid
+
+import pika
+
+from twisted.internet import defer
+
+
+class Consumer(object):
+    """
+    Represents a Twisted AMQP consumer and is returned from the call to
+    :func:`fedora_messaging.api.twisted_consume`.
+
+    Attributes:
+        queue (str): The AMQP queue this consumer is subscribed to.
+        callback (callable): The callback to run when a message arrives.
+        result (twisted.internet.defer.Deferred):
+            A deferred that runs the callbacks if the consumer exits gracefully
+            after being canceled by a call to :meth:`Consumer.cancel` and
+            errbacks if the consumer stops for any other reason. The reasons a
+            consumer could stop are: a :class:`.HaltConsumer` is raised by the
+            consumer indicating it wishes to halt, an unexpected
+            :class:`Exception` is raised by the consumer, or if the consumer is
+            canceled by the server which happens if the queue is deleted by an
+            administrator or if the node the queue lives on fails.
+    """
+
+    def __init__(self, queue=None, callback=None):
+        self.queue = queue
+        self.callback = callback
+        self.result = defer.Deferred()
+
+        # The current channel used by this consumer.
+        self._channel = None
+        # The unique ID for the AMQP consumer.
+        self._tag = str(uuid.uuid4())
+        # Used in the consumer read loop to know when it's being canceled.
+        self._running = True
+        # The current read loop
+        self._read_loop = None
+        # The protocol that currently runs this consumer, used when cancel is
+        # called to remove itself from the protocol and its factory so it doesn't
+        # restart on the next connection.
+        self._protocol = None
+
+    def __repr__(self):
+        return "Consumer(queue={}, callback={})".format(self.queue, self.callback)
+
+    @defer.inlineCallbacks
+    def cancel(self):
+        """
+        Cancel the consumer and clean up resources associated with it.
+        Consumers that are canceled are allowed to finish processing any
+        messages before halting.
+
+        Returns:
+            defer.Deferred: A deferred that fires when the consumer has finished
+            processing any message it was in the middle of and has been successfully
+            canceled.
+        """
+        # Remove it from protocol and factory so it doesn't restart later.
+        try:
+            del self._protocol._consumers[self.queue]
+        except (KeyError, AttributeError):
+            pass
+        try:
+            del self._protocol.factory._consumers[self.queue]
+        except (KeyError, AttributeError):
+            pass
+        # Signal to the _read loop it's time to stop and wait for it to finish
+        # with whatever message it might be working on, then wait for the deferred
+        # to fire which indicates it is done.
+        self._running = False
+        yield self._read_loop
+        try:
+            yield self._channel.basic_cancel(consumer_tag=self._tag)
+        except pika.exceptions.AMQPChannelError:
+            # Consumers are tied to channels, so if this channel is dead the
+            # consumer should already be canceled (and we can't get to it anyway)
+            pass
+        try:
+            yield self._channel.close()
+        except pika.exceptions.AMQPChannelError:
+            pass
+        if not self.result.called:
+            self.result.callback(self)

--- a/news/PR139.feature
+++ b/news/PR139.feature
@@ -1,0 +1,4 @@
+A new API, :func:`fedora_messaging.api.twisted_consume`, has been added to
+support consuming using the popular async framework Twisted. The
+fedora-messaging command-line interface has been switched to use this API. As
+a result, Twisted 12.2+ is now a dependency of fedora-messsaging.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ blinker
 click
 jsonschema
 toml
+Twisted
 pytz
 pika>=0.12
 six


### PR DESCRIPTION
This adds two new APIs to fedora-messaging:

1. twisted_consume() provides a way for users to start AMQP consumers that
   run until explicitly canceled or until a fatal error occurs on the
   broker.

2. twisted_cancel_consume() stops consumers started by
   twisted_consume().

This introduces new versions of the Protocol, Factory, and Service
classes as the APIs of these Twisted classes had to change. The original
classes have been deprecated and will be removed in fedora-messaging
v2.0.0.

Note: this is currently a work-in-progress - documentation and a few more tests are required. I'm just making sure the Ubuntu-based CI is passing with the new integration tests.