### PR TITLE
[Docs] Add instructions for installing the library and RabbitMQ in Docker

### DIFF
--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -15,9 +15,11 @@ Create a Python virtual environment::
 
 Install the library and its dependencies::
 
+    pip install fedora-messaging
+    # Alternatively, install it directly from the git repository
     git clone https://github.com/fedora-infra/fedora-messaging.git
     cd fedora-messaging
-    python setup.py develop
+    pip install -e .
 
 Make sure it is available and working::
 
@@ -38,6 +40,9 @@ http://localhost:15672/. The username is ``guest`` and the password is
 read the messages in the queues. Keep it open in a browser tab, we'll need it
 later.
 
+If your project uses containers, consult the `RabbitMQ documentation`_ about containers.
+
+.. _RabbitMQ documentation: https://www.rabbitmq.com/download.html#docker
 
 Configuration
 -------------


### PR DESCRIPTION
This PR adds pointers for installing fedora-messaging and setting up RabbitMQ in dockerised applications
as suggested by @jeremycline [here](https://pagure.io/fedora-commops/fedora-happiness-packets/issue/96#comment-558547) in the tutorial docs.