### PR TITLE
Add better error handling for permission denied cases

### DIFF
--- a/fedora_messaging/api.py
+++ b/fedora_messaging/api.py
@@ -95,8 +95,11 @@ def twisted_consume(callback, bindings=None, queues=None):
             meant to survive network problems, so consuming will continue until
             :meth:`.Consumer.cancel` is called or a fatal server error occurs.
             The deferred returned by this function may error back with a
-            :class:`fedora_messaging.exceptions.BadDeclaration` if the consumer
-            cannot be registered on the broker.
+            :class:`fedora_messaging.exceptions.BadDeclaration` queues or
+            bindings cannot be declared on the broker, or
+            :class:`fedora_messaging.exceptions.ConnectionException` if the TLS
+            or AMQP handshake fails.
+
     """
     if isinstance(bindings, dict):
         bindings = [bindings]

--- a/fedora_messaging/exceptions.py
+++ b/fedora_messaging/exceptions.py
@@ -9,7 +9,34 @@ class NoFreeChannels(BaseException):
     """Raised when a connection has reached its channel limit"""
 
 
-class BadDeclaration(BaseException):
+class PermissionException(BaseException):
+    """
+    Generic permissions exception.
+
+    Args:
+        obj_type (str): The type of object being accessed that caused the
+            permission error. May be None if the cause is unknown.
+        description (object): The description of the object, if any. May be None.
+        reason (str): The reason the server gave for the permission error, if
+            any. If no reason is supplied by the server, this should be the best
+            guess for what caused the error.
+    """
+
+    def __init__(self, obj_type=None, description=None, reason=None):
+        self.obj_type = obj_type
+        self.description = description
+        self.reason = reason
+
+    def __str__(self):
+        return self.description
+
+    def __repr__(self):
+        return "PermissionException(obj_type={}, description={}, reason={})".format(
+            self.obj_type, self.description, self.reason
+        )
+
+
+class BadDeclaration(PermissionException):
     """
     Raised when declaring an object in AMQP fails.
 
@@ -20,10 +47,15 @@ class BadDeclaration(BaseException):
         reason (str): The reason the server gave for rejecting the declaration.
     """
 
-    def __init__(self, obj_type, description, reason):
-        self.obj_type = obj_type
-        self.description = description
-        self.reason = reason
+    def __str__(self):
+        return "Unable to declare the {} object ({}) because {}".format(
+            self.obj_type, self.description, self.reason
+        )
+
+    def __repr__(self):
+        return "BadDeclaration(obj_type={}, description={}, reason={})".format(
+            self.obj_type, self.description, self.reason
+        )
 
 
 class ConfigurationException(BaseException):
@@ -67,9 +99,9 @@ class ConnectionException(BaseException):
     message.
     """
 
-    def __init__(self, reason=None, **kwargs):
-        super(ConnectionException, self).__init__(**kwargs)
-        self.reason = reason
+    def __init__(self, *args, **kwargs):
+        super(ConnectionException, self).__init__(*args)
+        self.reason = kwargs.get("reason")
 
 
 class ConsumeException(BaseException):

--- a/fedora_messaging/tests/integration/test_cli.py
+++ b/fedora_messaging/tests/integration/test_cli.py
@@ -24,9 +24,9 @@ import pytest
 import requests
 
 from fedora_messaging import api, exceptions, message
+from fedora_messaging.tests import FIXTURES_DIR
 
 
-FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../fixtures/"))
 CLI_CONF = os.path.join(FIXTURES_DIR, "cli_integration.toml")
 
 

--- a/fedora_messaging/tests/unit/test_cli.py
+++ b/fedora_messaging/tests/unit/test_cli.py
@@ -26,9 +26,9 @@ from twisted.python import failure
 import mock
 
 from fedora_messaging import cli, config, exceptions
+from fedora_messaging.tests import FIXTURES_DIR
 from fedora_messaging.twisted import consumer
 
-FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../fixtures/"))
 GOOD_CONF = os.path.join(FIXTURES_DIR, "good_conf.toml")
 BAD_CONF = os.path.join(FIXTURES_DIR, "bad_conf.toml")
 

--- a/fedora_messaging/twisted/consumer.py
+++ b/fedora_messaging/twisted/consumer.py
@@ -35,11 +35,14 @@ class Consumer(object):
             A deferred that runs the callbacks if the consumer exits gracefully
             after being canceled by a call to :meth:`Consumer.cancel` and
             errbacks if the consumer stops for any other reason. The reasons a
-            consumer could stop are: a :class:`.HaltConsumer` is raised by the
-            consumer indicating it wishes to halt, an unexpected
-            :class:`Exception` is raised by the consumer, or if the consumer is
-            canceled by the server which happens if the queue is deleted by an
-            administrator or if the node the queue lives on fails.
+            consumer could stop are: a
+            :class:`fedora_messaging.exceptions.PermissionExecption` if the
+            consumer does not have permissions to read from the queue it is
+            subscribed to, a :class:`.HaltConsumer` is raised by the consumer
+            indicating it wishes to halt, an unexpected :class:`Exception` is
+            raised by the consumer, or if the consumer is canceled by the
+            server which happens if the queue is deleted by an administrator or
+            if the node the queue lives on fails.
     """
 
     def __init__(self, queue=None, callback=None):


### PR DESCRIPTION
There are a number of cases which weren't being properly handled on the
less-than-happy path for authentication:

1. If the user had no access to the vhost at all, it would endlessly
   reconnect without any indication of a problem.

2. If authentication failed, it would do the same thing as 1.

3. If the user had access to the vhost, but lacked read permissions, it
   would set up the queue, configure the subscriber, and then would fail
   to read from the queue. The channel would be closed and it would
   assume it was a connection problem, but the connection was fine. The
   consumer would just hang.

For 1 and 2, a ConnectionException is now raised by ``twisted_consume``
as the connection is not going to improve with more retries.

For 3, a new exception has been added, PermissionException (of which
BadDeclaration is now a subclass), which is provided to the
consumer.result errback when there's a permission problem. This gives
the API users an opportunity to do something about it.

Case 3 is not properly handled by Pika 1.0.0b1 and b2 and its test is
skipped in that case. The 403 is never passed back to the reader of the
queue. We need to fix this upstream.