### PR TITLE
Add __repr__ implementations to the Twisted factory

### DIFF
--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -286,6 +286,12 @@ class FedoraMessagingFactoryV2(protocol.ReconnectingClientFactory):
         self._client = None
         self._consumers = {}
 
+    def __repr__(self):
+        """Return the representation of the factory as a string"""
+        return "FedoraMessagingFactoryV2(parameters={}, confirms={})".format(
+            self._parameters, self.confirms
+        )
+
     def buildProtocol(self, addr):
         """Create the Protocol instance.
 


### PR DESCRIPTION
This makes it look more useful when it is logged or printed during
debugging. Before, Twisted emitted the following log:

Starting factory
<fedora_messaging.twisted.factory.FedoraMessagingFactoryV2 object at
0x7f9aa4d4d358>

With this change, the log message becomes:

Starting factory FedoraMessagingFactoryV2(parameters=<URLParameters
host=rabbitmq.stg.fedoraproject.org port=5671
virtual_host=/public_pubsub ssl=True>, confirms=True)

which is much more helpful.

Signed-off-by: Jeremy Cline <jcline@redhat.com>