### PR TITLE
Add PyOpenSSL to the dependency list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jsonschema
 toml
 Twisted
 pytz
+PyOpenSSL
 pika>=0.12
 six
 service_identity


### PR DESCRIPTION
Twisted doesn't depend on PyOpenSSL, but its ssl module does use it. Add
it as an explicit dependency.

Signed-off-by: Jeremy Cline <jcline@redhat.com>