### PR TITLE
Add some copy/paste commands for getting connected

### DIFF
--- a/docs/fedora-broker.rst
+++ b/docs/fedora-broker.rst
@@ -44,6 +44,30 @@ repository and start with the following configuration file:
 
 .. literalinclude:: ../configs/fedora.toml
 
+Assuming the ``/etc/fedora-messaging/fedora.toml``,
+``/etc/fedora-messaging/cacert.pem``, ``/etc/fedora-messaging/fedora-key.pem``,
+and ``/etc/fedora-messaging/fedora-cert.pem`` files exist, the following
+command will create a configuration file called ``my_config.toml`` with a
+unique queue name for your consumer::
+
+    $ sed -e "s/[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}/$(uuidgen)/g" \
+        /etc/fedora-messaging/fedora.toml > my_config.toml
+
+Run a quick test to make sure you can connect to the broker. The configuration file
+comes with an example consumer which simply prints the message to standard output::
+
+    $ fedora-messaging --conf my_config.toml consume
+
+If all goes well, you'll see a log entry similar to::
+
+    Successfully registered AMQP consumer Consumer(queue=af0f78d2-159e-4279-b404-7b8c1b4649cc, callback=<function printer at 0x7f9a59e077b8>)
+
+This will be followed by the messages being sent inside Fedora's
+Infrastructure.  All that's left to do is change the callback in the
+configuration to use your consumer :ref:`conf-callback` and adjusting the
+routing keys in your :ref:`conf-bindings` to receive only the messages your
+consumer is interested in.
+
 
 .. _key: https://raw.githubusercontent.com/fedora-infra/fedora-messaging/master/configs/fedora-key.pem
 .. _certificate: https://raw.githubusercontent.com/fedora-infra/fedora-messaging/master/configs/fedora-cert.pem


### PR DESCRIPTION
With a single ugly sed command, users can create their own configuration
file. Add a set of instructions into the broker documentation so folks
can just copy/paste while experimenting.

Signed-off-by: Jeremy Cline <jcline@redhat.com>