### PR TITLE
 Handle general connection/channel exceptions when publishing 

### DIFF
--- a/fedora_messaging/tests/unit/test_cli.py
+++ b/fedora_messaging/tests/unit/test_cli.py
@@ -58,7 +58,7 @@ class ConsumeCliTests(unittest.TestCase):
     def tearDown(self):
         """Make sure each test has a fresh default configuration."""
         config.conf = config.LazyConfig()
-        config.conf.load_config()
+        config.conf.load_config(config_path="")
 
     @mock.patch("fedora_messaging.cli.api.twisted_consume")
     def test_good_conf(self, mock_consume):


### PR DESCRIPTION
If there's any channel or connection problem and we don't reset the
channel and connection, the next call to publish will fail with
something like a ChannelWrongStateError, so handle any ChannelError by
resetting everything.

This switches the exception handling order since NackError and company
are specific subclasses of AMQPChannelErrors and we handle those two
differently.
