### PR TITLE
Handle Pika 1.0.1+ consume permission exception

### DIFF
--- a/fedora_messaging/api.py
+++ b/fedora_messaging/api.py
@@ -95,8 +95,10 @@ def twisted_consume(callback, bindings=None, queues=None):
             meant to survive network problems, so consuming will continue until
             :meth:`.Consumer.cancel` is called or a fatal server error occurs.
             The deferred returned by this function may error back with a
-            :class:`fedora_messaging.exceptions.BadDeclaration` queues or
-            bindings cannot be declared on the broker, or
+            :class:`fedora_messaging.exceptions.BadDeclaration` if queues or
+            bindings cannot be declared on the broker, a
+            :class:`fedora_messaging.exceptions.PermissionException` if the user
+            doesn't have access to the queue, or
             :class:`fedora_messaging.exceptions.ConnectionException` if the TLS
             or AMQP handshake fails.
 

--- a/fedora_messaging/cli.py
+++ b/fedora_messaging/cli.py
@@ -189,6 +189,12 @@ def _consume_errback(failure):
             failure.value.reason,
         )
         _exit_code = 10
+    elif failure.check(exceptions.PermissionException):
+        _exit_code = 15
+        _log.error(
+            "The consumer could not proceed because of a permissions problem: %s",
+            str(failure.value),
+        )
     elif failure.check(exceptions.ConnectionException):
         _exit_code = 14
         _log.error(failure.value.reason)

--- a/fedora_messaging/tests/integration/test_twisted_api.py
+++ b/fedora_messaging/tests/integration/test_twisted_api.py
@@ -521,7 +521,7 @@ def test_no_vhost_permissions(admin_user):
 @pytest_twisted.inlineCallbacks
 @pytest.mark.skipif(
     _pika_version >= pkg_resources.parse_version("1.0.0b1"),
-    reason="This is currently broken in pika 1.0.0b1 and b2",
+    reason="This only works in pika-0.13 and lower",
 )
 def test_no_read_permissions_queue_read_failure(admin_user):
     """
@@ -552,6 +552,42 @@ def test_no_read_permissions_queue_read_failure(admin_user):
         )
     except (defer.TimeoutError, defer.CancelledError):
         pytest.fail("Timeout reached without consumer calling its errback!")
+
+
+@pytest_twisted.inlineCallbacks
+@pytest.mark.skipif(
+    _pika_version < pkg_resources.parse_version("1.0.1"),
+    reason="Pika-1.0.1+ raises its permission exception on consume",
+)
+def test_no_read_permissions_queue_read_failure_pika1(admin_user):
+    """
+    Assert an errback occurs when unable to read from the queue due to
+    permissions. This is a bit weird because the consumer has permission to
+    register itself, but not to actually read from the queue so the result is
+    what errors back.
+    """
+    url = "{base}permissions/%2F/{user}".format(base=HTTP_API, user=admin_user)
+    body = {"configure": ".*", "write": ".*", "read": ""}
+    resp = yield treq.put(url, json=body, auth=HTTP_AUTH, timeout=3)
+    assert resp.code == 204
+
+    queue = str(uuid.uuid4())
+    queues = {queue: {"auto_delete": False, "arguments": {"x-expires": 60 * 1000}}}
+
+    amqp_url = "amqp://{user}:guest@localhost:5672/%2F".format(user=admin_user)
+    with mock.patch.dict(config.conf, {"amqp_url": amqp_url}):
+        try:
+            consumers = api.twisted_consume(lambda x: x, [], queues)
+            _add_timeout(consumers, 5)
+            yield consumers
+            pytest.fail("Call failed to raise an exception")
+        except exceptions.PermissionException as e:
+            assert e.reason == (
+                "ACCESS_REFUSED - access to queue '{}' in vhost '/' refused for user "
+                "'{}'".format(queue, admin_user)
+            )
+        except (defer.TimeoutError, defer.CancelledError):
+            pytest.fail("Timeout reached without consumer calling its errback!")
 
 
 @pytest_twisted.inlineCallbacks

--- a/fedora_messaging/tests/unit/test_cli.py
+++ b/fedora_messaging/tests/unit/test_cli.py
@@ -398,3 +398,49 @@ class ConsumeCallbackTests(unittest.TestCase):
         mock_log.error.assert_called_once_with(
             "Unexpected error occurred in consumer %r: %r", consumers[0], f
         )
+
+
+class ConsumeErrbackTests(unittest.TestCase):
+    """Unit tests for the twisted_consume errback."""
+
+    def setUp(self):
+        cli._exit_code = 0
+
+    def tearDown(self):
+        cli._exit_code = 0
+
+    @mock.patch("fedora_messaging.cli.reactor")
+    def test_errback_permission(self, mock_reactor):
+        """Assert permission exceptions are caught and exit with 15."""
+        f = failure.Failure(exceptions.PermissionException("queue", "boop", "none"))
+
+        cli._consume_errback(f)
+
+        self.assertEqual(15, cli._exit_code)
+
+    @mock.patch("fedora_messaging.cli.reactor")
+    def test_errback_bad_declaration(self, mock_reactor):
+        """Assert declaration exceptions are caught and exit with 10."""
+        f = failure.Failure(exceptions.BadDeclaration("queue", "boop", "none"))
+
+        cli._consume_errback(f)
+
+        self.assertEqual(10, cli._exit_code)
+
+    @mock.patch("fedora_messaging.cli.reactor")
+    def test_errback_connection_exception(self, mock_reactor):
+        """Assert connection exceptions are caught and exit with 14."""
+        f = failure.Failure(exceptions.ConnectionException(reason="eh"))
+
+        cli._consume_errback(f)
+
+        self.assertEqual(14, cli._exit_code)
+
+    @mock.patch("fedora_messaging.cli.reactor")
+    def test_errback_general_exception(self, mock_reactor):
+        """Assert general exceptions are caught and exit with 11."""
+        f = failure.Failure(Exception("boop"))
+
+        cli._consume_errback(f)
+
+        self.assertEqual(11, cli._exit_code)


### PR DESCRIPTION
Add a documentation note for the PermissionException, a test, and handle
it in the CLI. See https://github.com/pika/pika/pull/1202 for the pika
issue.

Signed-off-by: Jeremy Cline <jcline@redhat.com>