### PR TITLE
Add a "--callback-file" option

### DIFF
--- a/fedora_messaging/tests/fixtures/bad_cb
+++ b/fedora_messaging/tests/fixtures/bad_cb
@@ -1,0 +1,1 @@
+not a valid python file

--- a/fedora_messaging/tests/fixtures/callback.py
+++ b/fedora_messaging/tests/fixtures/callback.py
@@ -1,0 +1,2 @@
+def rand(message):
+    return 4

--- a/news/159.feature
+++ b/news/159.feature
@@ -1,0 +1,3 @@
+"fedora-messaging consume" now accepts a "--callback-file" argument which will
+load a callback function from an arbitrary Python file. Previously, it was
+required that the callback be in the Python path.


### PR DESCRIPTION
Previously, the callback needed to reside on the Python Path, which is
convenient if you're already making a Python package. Plenty of folks
aren't, though, so allow users to provide a file that we'll boldly exec
and load a callback from.

Fixes #159

Note: I added this as a new option since I was concerned about messing up distinguishing the filesystem path from the Python path cases. This way the user is explicit, at the expense of things not quite Just Working. Feedback welcome on that decision.