### PR TITLE
WIP: Start on a set of common callbacks

### DIFF
--- a/docs/consuming.rst
+++ b/docs/consuming.rst
@@ -205,6 +205,15 @@ convenience. It is called ``fm-consumer@.service`` and simply runs
     $ systemctl start fm-consumer@sample.service  # uses /etc/fedora-messaging/sample.toml
 
 
+Common Consumers
+================
+
+Several generally useful consumers are shipped with fedora-messaging.
+
+.. autofunction:: fedora_messaging.callbacks.printer
+.. autofunction:: fedora_messaging.callbacks.run
+
+
 .. _AMQP overview: https://www.rabbitmq.com/tutorials/amqp-concepts.html
 .. _RabbitMQ tutorials: https://www.rabbitmq.com/getstarted.html
 .. _pika: https://pika.readthedocs.io/

--- a/fedora_messaging/callbacks.py
+++ b/fedora_messaging/callbacks.py
@@ -59,7 +59,7 @@ def run(message):
         processing. Defaults to no timeout.
     """
     try:
-        subprocess.check_call(
+        subprocess.check_call(  # nosec
             config.conf["consumer_config"]["command"],
             shell=config.conf["consumer_config"].get("shell", False),
             timeout=config.conf["consumer_config"].get("timeout"),

--- a/fedora_messaging/callbacks.py
+++ b/fedora_messaging/callbacks.py
@@ -17,7 +17,14 @@
 """This module contains a set of callbacks that are generally useful."""
 from __future__ import print_function
 
+import logging
+import subprocess
+
 import six
+
+from . import config, exceptions
+
+_log = logging.getLogger(__name__)
 
 
 def printer(message):
@@ -30,3 +37,40 @@ def printer(message):
         message (fedora_messaging.api.Message): The message that was received.
     """
     print(six.text_type(message))
+
+
+def run(message):
+    """
+    Run a command in a subprocess.
+
+    **Configuration Options**
+
+    This consumer uses the following configuration keys in the :ref:`conf-consumer-config`
+    section of the configuration file:
+
+    * ``command`` (string or list of strings): The arguments to launch the process
+        as a string or list of strings.
+    * ``shell`` (boolean): Whether or not to execute the command in a shell. Refer to the
+        `security considerations
+        <https://docs.python.org/3/library/subprocess.html#security-considerations>`_
+        before setting this to true. Defaults to false.
+    * ``timeout`` (integer): The length of time, in seconds, to wait on the command
+        before halting the command and returning the message to the queue for later
+        processing. Defaults to no timeout.
+    """
+    try:
+        subprocess.check_call(
+            config.conf["consumer_config"]["command"],
+            shell=config.conf["consumer_config"].get("shell", False),
+            timeout=config.conf["consumer_config"].get("timeout"),
+        )
+    except subprocess.CalledProcessError:
+        raise exceptions.Drop()
+    except subprocess.TimeoutExpired as e:
+        _log.error(
+            "{} failed to return after {} seconds; returning {} to the queue",
+            e.cmd,
+            e.timeout,
+            str(message.id),
+        )
+        raise exceptions.Nack()

--- a/fedora_messaging/callbacks.py
+++ b/fedora_messaging/callbacks.py
@@ -1,5 +1,5 @@
 # This file is part of fedora_messaging.
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2019 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,10 +14,19 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-"""
-Example consumers that can be used when starting out with the library to test.
+"""This module contains a set of callbacks that are generally useful."""
+from __future__ import print_function
 
-.. note:: This module is deprecated in favor of :mod:`fedora_messaging.callbacks`.
-"""
+import six
 
-from .callbacks import printer  # noqa: F401
+
+def printer(message):
+    """
+    A simple callback that prints the message to standard output.
+
+    Usage: ``fedora-messaging consume --callback="fedora_messaging.callbacks:printer"``
+
+    Args:
+        message (fedora_messaging.api.Message): The message that was received.
+    """
+    print(six.text_type(message))

--- a/fedora_messaging/tests/unit/test_callbacks.py
+++ b/fedora_messaging/tests/unit/test_callbacks.py
@@ -1,5 +1,5 @@
 # This file is part of fedora_messaging.
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2020 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,18 +14,19 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-"""Tests for :mod:`fedora_messaging.example`."""
+"""Tests for :mod:`fedora_messaging.callbacks`."""
 
 try:
     from io import StringIO
 except ImportError:
     # Python 2
     from StringIO import StringIO
+
 import unittest
 
 import mock
 
-from fedora_messaging import api, example
+from fedora_messaging import api, callbacks, config
 
 
 class PrinterTests(unittest.TestCase):
@@ -48,6 +49,18 @@ class PrinterTests(unittest.TestCase):
         )
 
         with mock.patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            example.printer(message)
+            callbacks.printer(message)
 
         self.assertEqual(expected_stdout, mock_stdout.getvalue())
+
+
+class RunnerTests(unittest.TestCase):
+    def test_runner(self):
+        """ Assert the run callback calls a subprocess."""
+        config.conf = config.LazyConfig()
+        config.conf["consumer_config"]["command"] = "/bin/true"
+        message = api.Message(body="Hello world", topic="hi")
+        with mock.patch("subprocess.check_call") as mock_subprocess:
+            callbacks.run(message)
+
+        mock_subprocess.assert_called_once_with("/bin/true", shell=False, timeout=None)


### PR DESCRIPTION
Move the printer callback into the "callbacks" module and add the callback requested in #155.

There are no tests yet because I wanted to get a bit of feedback on usage. @nirik, would the command ever need to see the message itself, or is this purely a way to trigger a command based on the topic alone? Would it ever be helpful to requeue the message and run the command again if it gets stuck while running or exits with some non-zero return code?

The current configuration options are:
* ``command`` (string or list of strings): The arguments to launch the process
        as a string or list of strings.
* ``shell`` (boolean): Whether or not to execute the command in a shell. Refer to the
        `security considerations
        <https://docs.python.org/3/library/subprocess.html#security-considerations>`_
        before setting this to true. Defaults to false.
* ``timeout`` (integer): The length of time, in seconds, to wait on the command
        before halting the command and returning the message to the queue for later
        processing. Defaults to no timeout.

Would anything else be useful to configure here?