### PR TITLE
Improve the readability of the API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,12 +9,18 @@ This documentation covers the public interfaces fedora_messaging provides.
 
 .. _semantic versioning 2.0.0: http://semver.org/
 
+.. contents:: API Table of Contents
+    :local:
+    :depth: 4
+
 
 .. _pub-api:
 
 Publishing
 ==========
 
+publish
+-------
 .. autofunction:: fedora_messaging.api.publish
 
 
@@ -23,11 +29,17 @@ Publishing
 Subscribing
 ===========
 
+twisted_consume
+---------------
 .. autofunction:: fedora_messaging.api.twisted_consume
 
+Consumer
+--------
 .. autoclass:: fedora_messaging.api.Consumer
    :members:
 
+consume
+-------
 .. autofunction:: fedora_messaging.api.consume
 
 
@@ -38,8 +50,16 @@ Signals
 
 .. automodule:: fedora_messaging.signals
 
+pre_publish_signal
+------------------
 .. autodata:: fedora_messaging.api.pre_publish_signal
+
+publish_signal
+--------------
 .. autodata:: fedora_messaging.api.publish_signal
+
+publish_failed_signal
+---------------------
 .. autodata:: fedora_messaging.api.publish_failed_signal
 
 
@@ -49,7 +69,13 @@ Message Schemas
 ===============
 
 .. automodule:: fedora_messaging.message
-   :members: Message, get_class
+
+Message
+-------
+
+.. autoclass:: fedora_messaging.message.Message
+   :members:
+   :special-members: __str__
 
 .. _message-severity:
 
@@ -61,9 +87,20 @@ applications like the notification service to determine what messages to send
 to users. The severity can be set at the class level, or on a message-by-message
 basis. The following are valid severity levels:
 
+DEBUG
+~~~~~
 .. autodata:: fedora_messaging.message.DEBUG
+
+INFO
+~~~~
 .. autodata:: fedora_messaging.message.INFO
+
+WARNING
+~~~~~~~
 .. autodata:: fedora_messaging.message.WARNING
+
+ERROR
+~~~~~
 .. autodata:: fedora_messaging.message.ERROR
 
 .. _exceptions-api:
@@ -73,8 +110,10 @@ Utilities
 ---------
 
 .. automodule:: fedora_messaging.schema_utils
-   :members:
 
+libravatar_url
+~~~~~~~~~~~~~~
+.. autofunction:: fedora_messaging.schema_utils.libravatar_url
 
 Exceptions
 ==========

--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -25,7 +25,8 @@ Secondly, it allows you to change your message format in a controlled fashion
 by versioning your schema. You can then choose to implement methods one way or
 another based on the version of the schema used by a message.
 
-Message schema are defined using `JSON Schema`_.
+Message schema are defined using `JSON Schema`_. The complete API can be found
+in the :ref:`message-api` API documentation.
 
 
 .. _header-schema:


### PR DESCRIPTION
This expands the message API documentation and adds a table of content
to the top of the API docs, separating each function or class with a
sub-header. It should provide a high level overview of the complete API
at a glance, and fleshes out some of the API documentation that was
lacking in the Message class.

Fixes: #164
Fixes: #166

Signed-off-by: Jeremy Cline <jcline@redhat.com>