### PR TITLE
Retry publishing for all connection-related errors

### DIFF
--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -153,7 +153,7 @@ class PublisherSession(object):
         except (pika_errs.NackError, pika_errs.UnroutableError) as e:
             _log.warning("Message was rejected by the broker (%s)", str(e))
             raise PublishReturned(reason=e)
-        except (pika_errs.ConnectionClosed, pika_errs.AMQPChannelError):
+        except (pika_errs.AMQPConnectionError, pika_errs.AMQPChannelError):
             # Because this is a blocking connection (and thus can't heartbeat)
             # we might need to restart the connection.
             _log.info("Resetting connection to %s", self._parameters.host)

--- a/fedora_messaging/tests/unit/test_session.py
+++ b/fedora_messaging/tests/unit/test_session.py
@@ -203,7 +203,7 @@ class PublisherSessionTests(unittest.TestCase):
 
     def test_publish_disconnected(self):
         # The publisher must try to re-establish a connection on publish.
-        self.publisher_channel_publish.side_effect = pika_errs.ConnectionClosed(
+        self.publisher_channel_publish.side_effect = pika_errs.AMQPConnectionError(
             200, "I wanted to"
         )
         connection_class_mock = mock.Mock()


### PR DESCRIPTION
Previously publishing was only retried if the connection was closed
cleanly. However, it might close for other reasons (someone trips over a
cord, a firewall kills a connection, etc). We should go through the
retry process for any connection exception.

Fixes #175

Signed-off-by: Jeremy Cline <jcline@redhat.com>