### PR TITLE
Reset the connection and channel for AMQP errors

### DIFF
--- a/fedora_messaging/_session.py
+++ b/fedora_messaging/_session.py
@@ -167,10 +167,13 @@ class PublisherSession(object):
                 _log.error(str(e))
                 if self._connection and self._connection.is_open:
                     self._connection.close()
+                self._connection = self._channel = None
                 raise ConnectionException(reason=e)
         except pika_errs.AMQPError as e:
+            _log.info("Resetting connection to %s", self._parameters.host)
             if self._connection and self._connection.is_open:
                 self._connection.close()
+            self._connection = self._channel = None
             raise ConnectionException(reason=e)
 
     def _connect_and_publish(self, exchange, message):


### PR DESCRIPTION
If a generic AMQP error occurs, do not try to re-use the connection. The
channel and connection has likely been closed because this is usually
due to protocol-level issues.

Signed-off-by: Jeremy Cline <jcline@redhat.com>