### PR TITLE
Add the "conf" and "DEFAULTS" variables to the API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -124,6 +124,22 @@ Exceptions
 
 .. _twisted-api:
 
+
+Configuration
+=============
+
+conf
+----
+
+.. autodata:: fedora_messaging.config.conf
+
+
+DEFAULTS
+--------
+
+.. autodata:: fedora_messaging.config.DEFAULTS
+
+
 Twisted
 =======
 

--- a/fedora_messaging/config.py
+++ b/fedora_messaging/config.py
@@ -290,7 +290,8 @@ _pika_version = pkg_resources.get_distribution("pika").version
 # A default, auto-deleted queue for consumers
 _default_queue_name = str(uuid.uuid4())
 
-#: A dictionary of application configuration defaults.
+#: The default configuration settings for fedora-messaging. This should not be
+#: modified and should be copied with :func:`copy.deepcopy`.
 DEFAULTS = dict(
     amqp_url="amqp://?connection_attempts=3&retry_delay=5",
     #: The default client properties reported to the AMQP broker in the "start-ok"
@@ -530,5 +531,5 @@ class LazyConfig(dict):
         return self
 
 
-#: The application configuration dictionary.
+#: The configuration dictionary used by fedora-messaging and consumers.
 conf = LazyConfig()


### PR DESCRIPTION
The config docs mention these, but they have not be officially
documented as part of the API. Include them.

Signed-off-by: Jeremy Cline <jcline@redhat.com>