### PR TITLE
Drop official Python 3.4 and 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,38 +30,26 @@ env:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=py27-pika1-unittest
+      env: TOXENV=py27-unittest
     - python: "3.6"
-      env: TOXENV=py36-pika1-unittest
+      env: TOXENV=py36-unittest
     - python: "3.7"
-      env: TOXENV=py37-pika1-unittest
+      env: TOXENV=py37-unittest
       dist: xenial
       sudo: required  # Force Travis to use a Ubuntu 16.04 VM that can run 3.7
     - python: "2.7"
-      env: TOXENV=py27-pika0x-unittest
+      env: TOXENV=py27-integration
+      sudo: required
+      services:
+        - rabbitmq
     - python: "3.6"
-      env: TOXENV=py36-pika0x-unittest
+      env: TOXENV=py36-integration
+      sudo: required
+      services:
+        - rabbitmq
     - python: "3.7"
-      env: TOXENV=py37-pika0x-unittest
+      env: TOXENV=py37-integration
       dist: xenial
-      sudo: required  # Force Travis to use a Ubuntu 16.04 VM that can run 3.7
-    - python: "2.7"
-      env: TOXENV=py27-pika1-integration
-      sudo: required
-      services:
-        - rabbitmq
-    - python: "3.6"
-      env: TOXENV=py36-pika1-integration
-      sudo: required
-      services:
-        - rabbitmq
-    - python: "2.7"
-      env: TOXENV=py27-pika0x-integration
-      sudo: required
-      services:
-        - rabbitmq
-    - python: "3.6"
-      env: TOXENV=py36-pika0x-integration
       sudo: required
       services:
         - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27-pika1-unittest
-    - python: "3.4"
-      env: TOXENV=py34-pika1-unittest
-    - python: "3.5"
-      env: TOXENV=py35-pika1-unittest
     - python: "3.6"
       env: TOXENV=py36-pika1-unittest
     - python: "3.7"
@@ -43,10 +39,6 @@ matrix:
       sudo: required  # Force Travis to use a Ubuntu 16.04 VM that can run 3.7
     - python: "2.7"
       env: TOXENV=py27-pika0x-unittest
-    - python: "3.4"
-      env: TOXENV=py34-pika0x-unittest
-    - python: "3.5"
-      env: TOXENV=py35-pika0x-unittest
     - python: "3.6"
       env: TOXENV=py36-pika0x-unittest
     - python: "3.7"
@@ -58,16 +50,6 @@ matrix:
       sudo: required
       services:
         - rabbitmq
-    - python: "3.4"
-      env: TOXENV=py34-pika1-integration
-      sudo: required
-      services:
-        - rabbitmq
-    - python: "3.5"
-      env: TOXENV=py35-pika1-integration
-      sudo: required
-      services:
-        - rabbitmq
     - python: "3.6"
       env: TOXENV=py36-pika1-integration
       sudo: required
@@ -75,16 +57,6 @@ matrix:
         - rabbitmq
     - python: "2.7"
       env: TOXENV=py27-pika0x-integration
-      sudo: required
-      services:
-        - rabbitmq
-    - python: "3.4"
-      env: TOXENV=py34-pika0x-integration
-      sudo: required
-      services:
-        - rabbitmq
-    - python: "3.5"
-      env: TOXENV=py35-pika0x-integration
       sudo: required
       services:
         - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,19 +40,19 @@ matrix:
     - python: "2.7"
       env: TOXENV=py27-integration
       sudo: required
-      services:
-        - rabbitmq
+      before_install:
+        - ./travis-integration-setup.sh
     - python: "3.6"
       env: TOXENV=py36-integration
       sudo: required
-      services:
-        - rabbitmq
+      before_install:
+        - ./travis-integration-setup.sh
     - python: "3.7"
       env: TOXENV=py37-integration
       dist: xenial
       sudo: required
-      services:
-        - rabbitmq
+      before_install:
+        - ./travis-integration-setup.sh
     - python: "3.6"
       env: TOXENV=docs
     - python: "3.6"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pika": ("https://pika.readthedocs.io/en/latest/", None),
     "jsonschema": ("https://python-jsonschema.readthedocs.io/en/latest/", None),
-    "six": ("https://pythonhosted.org/six/", None),
+    "six": ("https://six.readthedocs.io/", None),
     "blinker": ("https://pythonhosted.org/blinker/", None),
     "Twisted": ("https://twistedmatrix.com/documents/current/api/", None),
 }

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -30,7 +30,7 @@ Guidelines
 
 Python Support
 --------------
-fedora-messaging supports Python 2.7 and Python 3.4 or greater. This is
+fedora-messaging supports Python 2.7 and Python 3.6 or greater. This is
 automatically enforced by the continuous integration (CI) suite.
 
 

--- a/fedora_messaging/tests/integration/test_publish_consume.py
+++ b/fedora_messaging/tests/integration/test_publish_consume.py
@@ -11,13 +11,10 @@ import socket
 from twisted.internet import reactor, task
 import mock
 import pika
-import pkg_resources
-import pytest
 import pytest_twisted
 
 from fedora_messaging import api, message, exceptions
 from fedora_messaging.twisted import service
-from fedora_messaging.twisted.protocol import _pika_version
 
 
 class PubSubTests(unittest.TestCase):
@@ -71,10 +68,6 @@ class PubSubTests(unittest.TestCase):
         self.assertRaises(exceptions.ConnectionException, api.publish, api.Message())
 
 
-@pytest.mark.skipif(
-    _pika_version < pkg_resources.parse_version("1.0.0b1"),
-    reason="Twisted with confirms only supported on pika-1.0.0b1+",
-)
 @pytest_twisted.inlineCallbacks
 def test_check_confirms():
     """Assert confirmations are enabled by default."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ toml
 Twisted
 pytz
 PyOpenSSL
-pika>=0.12
+pika>=1.0.1
 six
 service_identity

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = lint,format,licenses,bandit,{py27,py36,py37}-pika{0x,1}-{unittest,integration}
+envlist = lint,format,licenses,bandit,{py27,py36,py37}-{unittest,integration}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 deps =
-    pika0x: pika<1.0.0b1
-    pika1: git+https://github.com/pika/pika.git
     -rdev-requirements.txt
 sitepackages = False
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,format,licenses,bandit,{py27,py34,py35,py36,py37}-pika{0x,1}-{unittest,integration}
+envlist = lint,format,licenses,bandit,{py27,py36,py37}-pika{0x,1}-{unittest,integration}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*

--- a/travis-integration-setup.sh
+++ b/travis-integration-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+wget -O- https://www.rabbitmq.com/rabbitmq-release-signing-key.asc | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install -y rabbitmq-server
+sudo rabbitmq-plugins enable rabbitmq_management
+sudo systemctl start rabbitmq-server


### PR DESCRIPTION
Drop Python 3.4 and 3.5 from the CI configuration and mark Python 3.6 as
the lowest Python 3 version supported. EPEL7 has a Python 3.6 stack now.

This unfortunately expanded a bit because the CI was also broken due to Travis moving to Xenial by default and not installing RabbitMQ on those *and* because Six moved its docs. I went ahead and also dropped the Pika 0.x matrix because 1.0+ is available everywhere we care about.

Signed-off-by: Jeremy Cline <jcline@redhat.com>