### PR TITLE
Update example config: ZMQ exchange, extra properties, logging

### DIFF
--- a/configs/fedora.toml
+++ b/configs/fedora.toml
@@ -12,6 +12,12 @@ certfile = "/etc/fedora-messaging/fedora-cert.pem"
 
 [client_properties]
 app = "Example Application"
+# Some suggested extra fields:
+# URL of the project that provides this consumer
+app_url = "https://github.com/fedora-infra/fedora-messaging"
+# Contact emails for the maintainer(s) of the consumer - in case the
+# broker admin needs to contact them, for e.g.
+app_contacts_email = ["jcline@fedoraproject.org"]
 
 [exchanges."amq.topic"]
 type = "topic"
@@ -71,6 +77,14 @@ handlers = ["console"]
 level = "WARNING"
 propagate = false
 handlers = ["console"]
+
+# If your consumer sets up a logger, you must add a configuration for it
+# here in order for the messages to show up. e.g. if it set up a logger
+# called 'example_printer', you could do:
+#[log_config.loggers.example_printer]
+#level = "INFO"
+#propagate = false
+#handlers = ["console"]
 
 [log_config.root]
 level = "ERROR"


### PR DESCRIPTION
This is based on my experience porting several fedmsg consumers
to fedora-messaging. @jcline thought it would be good for
consumers to provide more useful info in client_properties, so
I invented a couple of optional fields there. Also you need a
second binding to receive messages from the ZMQ->AMQP bridge
(which most consumers are likely to want to do), and it seems
useful to note that if your consumer implements a logger, it
needs to be configured here or else messages won't show up.

Signed-off-by: Adam Williamson <awilliam@redhat.com>