### PR TITLE
Add MANIFEST.in and include tests for sample schema package

### DIFF
--- a/docs/sample_schema_package/MANIFEST.in
+++ b/docs/sample_schema_package/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE README

--- a/docs/sample_schema_package/setup.py
+++ b/docs/sample_schema_package/setup.py
@@ -48,7 +48,7 @@ setup(
     maintainer_email="infrastructure@lists.fedoraproject.org",
     platforms=["Fedora", "GNU/Linux"],
     keywords="fedora",
-    packages=find_packages(exclude=("mailman_schema.tests", "mailman_schema.tests.*")),
+    packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     install_requires=["fedora_messaging"],


### PR DESCRIPTION
This commit adds the following for the Sample Schema package (as discussed with @jeremycline): 

1. A MANIFEST.in that includes non-code files and test package
2. Not exclude the test package in setup.py
