### PR TITLE
Twisted legacy logging does not accept format parameters

### DIFF
--- a/fedora_messaging/tests/unit/twisted/test_factory.py
+++ b/fedora_messaging/tests/unit/twisted/test_factory.py
@@ -204,9 +204,7 @@ class FactoryTests(unittest.TestCase):
         ) as mock_log:
             self.factory.clientConnectionFailed(None, mock.Mock(value="something"))
         mock_log.msg.assert_called_once_with(
-            "Connection to the AMQP broker failed ({reason})",
-            reason="something",
-            logLevel=logging.WARNING,
+            "Connection to the AMQP broker failed (something)", logLevel=logging.WARNING
         )
 
     def test_stopTrying(self):

--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -131,8 +131,9 @@ class FedoraMessagingFactory(protocol.ReconnectingClientFactory):
         """
         if not isinstance(reason.value, error.ConnectionDone):
             _legacy_twisted_log.msg(
-                "Lost connection to the AMQP broker ({reason})",
-                reason=reason.value,
+                "Lost connection to the AMQP broker ({reason})".format(
+                    reason=reason.value
+                ),
                 logLevel=logging.WARNING,
             )
         if self._client_ready.called:
@@ -148,8 +149,9 @@ class FedoraMessagingFactory(protocol.ReconnectingClientFactory):
         `twisted.internet.protocol.ReconnectingClientFactory` for details.
         """
         _legacy_twisted_log.msg(
-            "Connection to the AMQP broker failed ({reason})",
-            reason=reason.value,
+            "Connection to the AMQP broker failed ({reason})".format(
+                reason=reason.value
+            ),
             logLevel=logging.WARNING,
         )
         protocol.ReconnectingClientFactory.clientConnectionFailed(

--- a/fedora_messaging/twisted/protocol.py
+++ b/fedora_messaging/twisted/protocol.py
@@ -668,31 +668,30 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
             except (error.ConnectionDone, ChannelClosedByClient):
                 # This is deliberate.
                 _legacy_twisted_log.msg(
-                    "Stopping the AMQP consumer with tag {tag}", tag=consumer.tag
+                    "Stopping the AMQP consumer with tag {tag}".format(tag=consumer.tag)
                 )
                 break
             except pika.exceptions.ChannelClosed as e:
                 _legacy_twisted_log.msg(
-                    "Stopping AMQP consumer {tag} for queue {q}: {e}",
-                    tag=consumer.tag,
-                    q=consumer.queue,
-                    e=str(e),
+                    "Stopping AMQP consumer {tag} for queue {q}: {e}".format(
+                        tag=consumer.tag, q=consumer.queue, e=str(e)
+                    ),
                     logLevel=logging.ERROR,
                 )
                 break
             except pika.exceptions.ConsumerCancelled as e:
                 _legacy_twisted_log.msg(
-                    "The AMQP broker canceled consumer {tag} on queue {q}: {e}",
-                    tag=consumer.tag,
-                    q=consumer.queue,
-                    e=str(e),
+                    "The AMQP broker canceled consumer {tag} on queue {q}: {e}".format(
+                        tag=consumer.tag, q=consumer.queue, e=str(e)
+                    ),
                     logLevel=logging.ERROR,
                 )
                 break
             except Exception:
                 _legacy_twisted_log.msg(
-                    "An unexpected error occurred consuming from queue {q}",
-                    q=consumer.queue,
+                    "An unexpected error occurred consuming from queue {q}".format(
+                        q=consumer.queue
+                    ),
                     logLevel=logging.ERROR,
                 )
                 break
@@ -726,9 +725,9 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
             Deferred: fired when the message has been handled.
         """
         _legacy_twisted_log.msg(
-            "Message arrived with delivery tag {tag} for {consumer}",
-            tag=delivery_frame.delivery_tag,
-            consumer=consumer,
+            "Message arrived with delivery tag {tag} for {consumer}".format(
+                tag=delivery_frame.delivery_tag, consumer=consumer
+            ),
             logLevel=logging.DEBUG,
         )
         try:
@@ -736,8 +735,9 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
             message.queue = consumer.queue
         except ValidationError:
             _legacy_twisted_log.msg(
-                "Message id {msgid} did not pass validation; ignoring message",
-                msgid=properties.message_id,
+                "Message id {msgid} did not pass validation; ignoring message".format(
+                    msgid=properties.message_id
+                ),
                 logLevel=logging.WARNING,
             )
             yield consumer.channel.basic_nack(
@@ -747,15 +747,16 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
 
         try:
             _legacy_twisted_log.msg(
-                "Consuming message from topic {topic!r} (id {msgid})",
-                topic=message.topic,
-                msgid=properties.message_id,
+                "Consuming message from topic {topic!r} (id {msgid})".format(
+                    topic=message.topic, msgid=properties.message_id
+                )
             )
             yield defer.maybeDeferred(consumer.callback, message)
         except Nack:
             _legacy_twisted_log.msg(
-                "Returning message id {msgid} to the queue",
-                msgid=properties.message_id,
+                "Returning message id {msgid} to the queue".format(
+                    msgid=properties.message_id
+                ),
                 logLevel=logging.WARNING,
             )
             yield consumer.channel.basic_nack(
@@ -763,8 +764,9 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
             )
         except Drop:
             _legacy_twisted_log.msg(
-                "Consumer requested message id {msgid} be dropped",
-                msgid=properties.message_id,
+                "Consumer requested message id {msgid} be dropped".format(
+                    msgid=properties.message_id
+                ),
                 logLevel=logging.WARNING,
             )
             yield consumer.channel.basic_nack(
@@ -778,8 +780,7 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
             yield self.cancel(consumer.queue)
         except Exception:
             _legacy_twisted_log.msg(
-                "Received unexpected exception from consumer {c}",
-                c=consumer,
+                "Received unexpected exception from consumer {c}".format(c=consumer),
                 logLevel=logging.ERROR,
             )
             yield consumer.channel.basic_nack(
@@ -840,11 +841,12 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
         deferred = self._read(queue_object, consumer)
         deferred.addErrback(
             lambda f: _legacy_twisted_log.msg,
-            "_read failed on consumer {c}",
-            c=consumer,
+            "_read failed on consumer {c}".format(c=consumer),
             logLevel=logging.ERROR,
         )
-        _legacy_twisted_log.msg("Successfully registered AMQP consumer {c}", c=consumer)
+        _legacy_twisted_log.msg(
+            "Successfully registered AMQP consumer {c}".format(c=consumer)
+        )
         defer.returnValue(consumer)
 
     @defer.inlineCallbacks
@@ -901,8 +903,7 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
             deferred = self._read(queue_object, consumer)
             deferred.addErrback(
                 lambda f: _legacy_twisted_log.msg,
-                "_read failed on consumer {c}",
-                c=consumer,
+                "_read failed on consumer {c}".format(c=consumer),
                 logLevel=logging.ERROR,
             )
         _legacy_twisted_log.msg("AMQP connection successfully established")


### PR DESCRIPTION
We currently have unformatted logs, like: `Stopping AMQP consumer {tag} for queue {q}: {e}`. This commit fixes it.