### PR TITLE
Clarify queues are only deleted if unused

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -72,8 +72,8 @@ These public queues have some restrictions applied to them. Firstly, they are
 limited to about 50 megabytes in size, so if your application cannot handle the
 message throughput messages will be automatically discarded once you hit this
 limit. Secondly, queues that are set to be durable (in other words, not
-exclusive or auto-deleted) are automatically deleted after approximately an
-hour.
+exclusive or auto-deleted) are automatically deleted if they have no consumers
+after approximately an hour.
 
 If you need more robust guarantees about message delivery, or if you need to
 publish messages into Fedora's message broker, contact the Fedora


### PR DESCRIPTION
The previous wording made it sound like it was deleted after an hour of
use.

Signed-off-by: Jeremy Cline <jcline@redhat.com>