### PR TITLE
Fix a reconnection issue

### DIFF
--- a/news/208.bug
+++ b/news/208.bug
@@ -1,0 +1,1 @@
+Fix an issue where reconnection to the server would fail.


### PR DESCRIPTION
Reconnecting twice in a row would trigger an `AlreadyCalledError` on the `_client_deferred` Deferred.