### PR TITLE
Handle ConnectionLost errors in the on_ready errbacks

### DIFF
--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -342,8 +342,9 @@ class FedoraMessagingFactoryV2(protocol.ReconnectingClientFactory):
                 # Renew the deferred to handle reconnections.
                 self._client_deferred = defer.Deferred()
             else:
-                _std_log.exception(
-                    "The connection failed with an unexpected exception; please report this bug."
+                _std_log.error(
+                    "The connection failed with an unexpected exception; please report this bug: %s",
+                    failure.getTraceback(),
                 )
                 self._client_deferred.errback(failure)
                 # Renew the deferred to handle reconnections.


### PR DESCRIPTION
This also alters the logging of general errors to capture the actual failure rather than the StopIteration exception from the inline callback generator.