### PR TITLE
Fix handling of new connections after a publish timeout

### DIFF
--- a/fedora_messaging/api.py
+++ b/fedora_messaging/api.py
@@ -314,7 +314,9 @@ def publish(message, exchange=None, timeout=30):
         publish_signal.send(publish, message=message)
     except crochet.TimeoutError:
         eventual_result.cancel()
-        wrapper = exceptions.PublishTimeout()
+        wrapper = exceptions.PublishTimeout(
+            "Publishing timed out after waiting {} seconds.".format(timeout)
+        )
         publish_failed_signal.send(publish, message=message, reason=wrapper)
         raise wrapper
     except Exception as e:

--- a/fedora_messaging/tests/integration/test_api.py
+++ b/fedora_messaging/tests/integration/test_api.py
@@ -734,6 +734,8 @@ def test_pub_timeout():
             pytest.fail("Expected a timeout exception, not {}".format(e))
     finally:
         sock.close()
+    # Ensure the deferred has been renewed
+    assert api._twisted_service._service.factory.when_connected().called is False
 
 
 @pytest_twisted.inlineCallbacks

--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -398,7 +398,12 @@ class FedoraMessagingFactoryV2(protocol.ReconnectingClientFactory):
             _std_log.debug(
                 "Waiting for %r to fire with new connection", self._client_deferred
             )
-            yield self._client_deferred
+            try:
+                yield self._client_deferred
+            except defer.CancelledError:
+                # Renew the deferred to handle future connections.
+                self._client_deferred = defer.Deferred()
+                raise
         defer.returnValue(self._client)
 
     @defer.inlineCallbacks

--- a/news/212.bug
+++ b/news/212.bug
@@ -1,0 +1,1 @@
+Fix handling of new connections after a publish timeout


### PR DESCRIPTION
When a `PublishTimeout` occurs, the `_client_deferred` is cancelled but it was not renewed, as it is in other cases.

Fixes: #212 
