### PR TITLE
Only try to restart fm-consumer@ services every 60 seconds

### DIFF
--- a/fm-consumer@.service
+++ b/fm-consumer@.service
@@ -6,6 +6,7 @@ Documentation=http://fedora-messaging.readthedocs.io/
 Type=simple
 ExecStart=/usr/bin/fedora-messaging --conf /etc/fedora-messaging/%i.toml consume
 Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Consumers using the fm-consumer@ service pattern are quite
vulnerable to a problem where, for instance, consuming a message
fails because some key service the consumer needs to talk to is
down. When this happens, the service is considered to have
failed, and - because Restart=on-failure is set - is immediately
(well, after 100ms) restarted. It then immediately attempts to
consume the same message, and - because the service likely
didn't come up in the last 100ms - probably fails again. This
continues to happen in a very fast cycle. If the consumer times
out quite quickly and the service stays down for several hours,
you can easily accumulate a loop of tens of thousands of
failures. This pollutes the system journal quite badly and is
a nightmare if you have the consumer configured to email the
administrator on failure; the admin's email will get tens of
thousands of failure mails.

Some kind of incremental backoff would be ideal here, but sadly
systemd doesn't have that implemented yet:
https://github.com/systemd/systemd/issues/6129
in its absence, this just sets RestartSec=60, meaning the
service will only be restarted every 60 seconds. This should
cut down the floods quite a lot.

Signed-off-by: Adam Williamson <awilliam@redhat.com>