### PR TITLE
Pytest 5.4 breaks the Twisted tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ sphinx
 mock
 twisted
 treq
-pytest
+pytest<=5.3.5
 pytest-twisted
 pyOpenSSL
 towncrier


### PR DESCRIPTION
Tests started failing the same day Pytest made a release. I can't be
bothered to set up a development environment again so I'm making this PR
to test the theory.

Signed-off-by: Jeremy Cline <jcline@redhat.com>