### PR TITLE
Set the QoS on the channel that is created for the consumer

### DIFF
--- a/fedora_messaging/tests/unit/twisted/test_protocol.py
+++ b/fedora_messaging/tests/unit/twisted/test_protocol.py
@@ -121,6 +121,10 @@ class ProtocolTests(unittest.TestCase):
 
         def _check(consumer):
             assert self.protocol._running is True
+            consumer.channel.basic_qos.assert_called_with(
+                prefetch_count=config.conf["qos"]["prefetch_count"],
+                prefetch_size=config.conf["qos"]["prefetch_size"],
+            )
             consumer.channel.basic_consume.assert_called_once_with(
                 queue="my_queue", consumer_tag="tag1"
             )
@@ -159,6 +163,10 @@ class ProtocolTests(unittest.TestCase):
         func = mock.Mock()
 
         def _check(consumer):
+            consumer.channel.basic_qos.assert_called_with(
+                prefetch_count=config.conf["qos"]["prefetch_count"],
+                prefetch_size=config.conf["qos"]["prefetch_size"],
+            )
             consumer.channel.basic_consume.assert_called_once_with(
                 queue="my_queue", consumer_tag="tag1"
             )
@@ -213,11 +221,7 @@ class ProtocolTests(unittest.TestCase):
     def test_connection_ready(self):
         # Check the ready Deferred.
         def _check(_):
-            self.protocol._channel.basic_qos.assert_called_with(
-                prefetch_count=config.conf["qos"]["prefetch_count"],
-                prefetch_size=config.conf["qos"]["prefetch_size"],
-                global_qos=True,
-            )
+            self.protocol.channel.assert_called_once_with()
 
         d = self.protocol.ready
         d.addCallback(_check)

--- a/fedora_messaging/twisted/protocol.py
+++ b/fedora_messaging/twisted/protocol.py
@@ -151,11 +151,6 @@ class FedoraMessagingProtocolV2(TwistedProtocolConnection):
                 versions lower than 1.0.0.
         """
         self._channel = yield self._allocate_channel()
-        yield self._channel.basic_qos(
-            prefetch_count=config.conf["qos"]["prefetch_count"],
-            prefetch_size=config.conf["qos"]["prefetch_size"],
-            global_qos=True,
-        )
 
     @defer.inlineCallbacks
     def _read(self, queue_object, consumer):
@@ -351,6 +346,10 @@ class FedoraMessagingProtocolV2(TwistedProtocolConnection):
             consumer = ConsumerV2(queue=queue, callback=callback)
         consumer._protocol = self
         consumer._channel = yield self._allocate_channel()
+        yield consumer._channel.basic_qos(
+            prefetch_count=config.conf["qos"]["prefetch_count"],
+            prefetch_size=config.conf["qos"]["prefetch_size"],
+        )
         try:
             queue_object, _ = yield consumer._channel.basic_consume(
                 queue=consumer.queue, consumer_tag=consumer._tag
@@ -826,6 +825,10 @@ class FedoraMessagingProtocol(FedoraMessagingProtocolV2):
             defer.returnValue(consumer)
 
         channel = yield self._allocate_channel()
+        yield channel.basic_qos(
+            prefetch_count=config.conf["qos"]["prefetch_count"],
+            prefetch_size=config.conf["qos"]["prefetch_size"],
+        )
         consumer = Consumer(
             tag=str(uuid.uuid4()), queue=queue, callback=callback, channel=channel
         )


### PR DESCRIPTION
According to [the RabbitMQ docs](https://www.rabbitmq.com/consumer-prefetch.html), they changed the semantics of the `global` QoS parameter, and setting it to `True` as we've done does not enforce the prefetch limit on all channels in the connection but rather on all consumers in the channel. There is no way to have connection-wide limits with RabbitMQ.

Since we create a new channel for each consumer, we must set the QoS in this channel and not in the main channel, otherwise it'll always be limitless.

Fixes #223