### PR TITLE
Expand the testing module a little bit

### DIFF
--- a/fedora_messaging/__init__.py
+++ b/fedora_messaging/__init__.py
@@ -15,4 +15,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+try:
+    import pytest
+
+    pytest.register_assert_rewrite("fedora_messaging.testing")
+except ImportError:
+    pass
+
+
 __version__ = "2.0.2"

--- a/fedora_messaging/testing.py
+++ b/fedora_messaging/testing.py
@@ -86,5 +86,7 @@ def mock_sends(*expected_messages):
                     )
                 )
         else:
+            assert msg.topic == expected.topic
+            assert msg.body == expected.body
             assert msg == expected
         msg.validate()

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = lint,format,licenses,bandit,{py27,py36,py37}-{unittest,integration}
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 deps =
+    pyrsistent<0.16;python_version<="2.7"
     -rdev-requirements.txt
 sitepackages = False
 commands =


### PR DESCRIPTION
- Allow to use the re-written assert statement from pytest which provides a much more detailed output of where the assertion failed
- Check the topic and body separately before checking the entire objects.