### PR TITLE
Support Forbidden errors on publish

### DIFF
--- a/docs/tutorial/conversion.rst
+++ b/docs/tutorial/conversion.rst
@@ -117,7 +117,7 @@ to encapsulate the messages. The wrapper could look like::
 
     from fedora_elections_messages.schema import Message
     from fedora_messaging.api import publish as fm_publish
-    from fedora_messaging.exceptions import PublishReturned, ConnectionException
+    from fedora_messaging.exceptions import PublishReturned, PublishForbidden, ConnectionException
 
     LOGGER = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ to encapsulate the messages. The wrapper could look like::
                 topic="fedora.elections." + topic,
                 body=msg,
             ))
-        except PublishReturned as e:
+        except (PublishReturned, PublishForbidden) as e:
             LOGGER.warning(
                 "Fedora Messaging broker rejected message %s: %s",
                 msg.id, e
@@ -235,7 +235,7 @@ Now you can replace the current call to fedmsg with a call to
 
     import logging
     from fedora_messaging.api import Message, publish
-    from fedora_messaging.exceptions import PublishReturned, ConnectionException
+    from fedora_messaging.exceptions import PublishReturned, PublishForbidden, ConnectionException
 
     LOGGER = logging.getLogger(__name__)
 
@@ -247,7 +247,7 @@ And replace the call to ``fedmsg.publish`` with::
             body=payload,
         )
         publish(msg)
-    except PublishReturned as e:
+    except (PublishReturned, PublishForbidden) as e:
         LOGGER.warning(
             "Fedora Messaging broker rejected message %s: %s",
             msg.id, e

--- a/docs/tutorial/exceptions.rst
+++ b/docs/tutorial/exceptions.rst
@@ -15,6 +15,8 @@ exceptions can be raised:
   its JSON schema. This only depends on the message you are trying to
   send, the AMQP server is not involved.
 - ``PublishReturned``: raised if the broker rejects the message.
+- ``PublishForbidden``: raised if the broker rejects the message because of
+  permissions issues.
 - ``ConnectionException``: raised if a connection error occurred before the
   publish confirmation arrived.
 

--- a/fedora_messaging/api.py
+++ b/fedora_messaging/api.py
@@ -298,6 +298,8 @@ def publish(message, exchange=None, timeout=30):
             message.
         fedora_messaging.exceptions.PublishTimeout: Raised if the broker could not be
             contacted in the given timeout time.
+        fedora_messaging.exceptions.PublishForbidden: Raised if the broker rejects the
+            message because of permission issues.
         fedora_messaging.exceptions.ValidationError: Raised if the message
             fails validation with its JSON schema. This only depends on the
             message you are trying to send, the AMQP server is not involved.

--- a/fedora_messaging/cli.py
+++ b/fedora_messaging/cli.py
@@ -383,7 +383,7 @@ def publish(exchange, file):
             click.echo("Publishing message with topic {}".format(msg.topic))
             try:
                 api.publish(msg, exchange)
-            except exceptions.PublishReturned as e:
+            except (exceptions.PublishReturned, exceptions.PublishForbidden) as e:
                 click.echo("Unable to publish message: {}".format(str(e)))
                 sys.exit(errno.EREMOTEIO)
             except exceptions.PublishTimeout as e:

--- a/fedora_messaging/exceptions.py
+++ b/fedora_messaging/exceptions.py
@@ -103,6 +103,15 @@ class PublishTimeout(PublishException):
     """
 
 
+class PublishForbidden(PublishException):
+    """
+    Raised when the broker rejects the message due to permission errors.
+
+    You may handle this exception by logging it and discarding the message,
+    as it is likely a permanent error.
+    """
+
+
 class ConnectionException(BaseException):
     """
     Raised if a general connection error occurred.

--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -249,6 +249,8 @@ class FedoraMessagingFactory(protocol.ReconnectingClientFactory):
 
         Raises:
             PublishReturned: If the published message is rejected by the broker.
+            PublishForbidden: If the published message is rejected by the broker because
+                of permission issues.
             ConnectionException: If a connection error occurs while publishing. Calling
                 this method again will wait for the next connection and publish when it
                 is available.
@@ -425,6 +427,8 @@ class FedoraMessagingFactoryV2(protocol.ReconnectingClientFactory):
                 If this occurs, you can either reduce the number of consumers on this
                 connection or create an additional connection.
             PublishReturned: If the published message is rejected by the broker.
+            PublishForbidden: If the published message is rejected by the broker because
+                of permission issues.
             ConnectionException: If a connection error occurs while publishing. Calling
                 this method again will wait for the next connection and publish when it
                 is available.

--- a/news/PR235.feature
+++ b/news/PR235.feature
@@ -1,0 +1,1 @@
+Handle [topic authorization](https://www.rabbitmq.com/access-control.html#topic-authorisation) by raising a ``PublishForbidden`` exception instead of being stuck in a retry loop


### PR DESCRIPTION
When [topic authorization](https://www.rabbitmq.com/access-control.html#topic-authorisation) is enabled, the broken can return Forbidden messages when messages are published to a forbidden topic. Handle this type of response instead of retrying endlessly.