### PR TITLE
Support anonymous (server-named) queues

### DIFF
--- a/configs/fedora.stg.toml
+++ b/configs/fedora.stg.toml
@@ -26,21 +26,26 @@ auto_delete = false
 arguments = {}
 
 # Queue names *must* be in the normal UUID format: run "uuidgen" and use the
-# output as your queue name. If your queue is not exclusive, anyone can connect
-# and consume from it, causing you to miss messages, so do not share your queue
-# name. Any queues that are not auto-deleted on disconnect are garbage-collected
-# after approximately one hour.
+# output as your queue name. If you don't define a queue here, the server will
+# generate a queue name for you. This queue will be non-durable, auto-deleted and
+# exclusive.
+# If your queue is not exclusive, anyone can connect and consume from it, causing
+# you to miss messages, so do not share your queue name. Any queues that are not
+# auto-deleted on disconnect are garbage-collected after approximately one hour.
 #
 # If you require a stronger guarantee about delivery, please talk to Fedora's
 # Infrastructure team.
-[queues.00000000-0000-0000-0000-000000000000]
-durable = false
-auto_delete = true
-exclusive = true
-arguments = {}
+#
+# [queues.00000000-0000-0000-0000-000000000000]
+# durable = false
+# auto_delete = true
+# exclusive = true
+# arguments = {}
 
+# If you use the server-generated queue names, you can leave out the "queue"
+# parameter in the bindings definition.
 [[bindings]]
-queue = "00000000-0000-0000-0000-000000000000"
+# queue = "00000000-0000-0000-0000-000000000000"
 exchange = "amq.topic"
 routing_keys = ["#"]  # Set this to the specific topics you are interested in.
 

--- a/configs/fedora.toml
+++ b/configs/fedora.toml
@@ -26,21 +26,26 @@ auto_delete = false
 arguments = {}
 
 # Queue names *must* be in the normal UUID format: run "uuidgen" and use the
-# output as your queue name. If your queue is not exclusive, anyone can connect
-# and consume from it, causing you to miss messages, so do not share your queue
-# name. Any queues that are not auto-deleted on disconnect are garbage-collected
-# after approximately one hour.
+# output as your queue name. If you don't define a queue here, the server will
+# generate a queue name for you. This queue will be non-durable, auto-deleted and
+# exclusive.
+# If your queue is not exclusive, anyone can connect and consume from it, causing
+# you to miss messages, so do not share your queue name. Any queues that are not
+# auto-deleted on disconnect are garbage-collected after approximately one hour.
 #
 # If you require a stronger guarantee about delivery, please talk to Fedora's
 # Infrastructure team.
-[queues.00000000-0000-0000-0000-000000000000]
-durable = false
-auto_delete = true
-exclusive = true
-arguments = {}
+#
+# [queues.00000000-0000-0000-0000-000000000000]
+# durable = false
+# auto_delete = true
+# exclusive = true
+# arguments = {}
 
+# If you use the server-generated queue names, you can leave out the "queue"
+# parameter in the bindings definition.
 [[bindings]]
-queue = "00000000-0000-0000-0000-000000000000"
+# queue = "00000000-0000-0000-0000-000000000000"
 exchange = "amq.topic"
 routing_keys = ["#"]  # Set this to the specific topics you are interested in.
 

--- a/fedora_messaging/cli.py
+++ b/fedora_messaging/cli.py
@@ -136,13 +136,6 @@ def _consume(exchange, queue_name, routing_key, callback, app_name):
     bindings = config.conf["bindings"]
     queues = config.conf["queues"]
 
-    # The CLI and config.DEFAULTS have different defaults for the queue
-    # settings at the moment.  We should select a universal default in the
-    # future and remove this. Unfortunately that will break backwards compatibility.
-    if queues == config.DEFAULTS["queues"]:
-        queues[config._default_queue_name]["durable"] = True
-        queues[config._default_queue_name]["auto_delete"] = False
-
     if queue_name:
         queues = {queue_name: config.conf["queues"][config._default_queue_name]}
         for binding in bindings:

--- a/fedora_messaging/config.py
+++ b/fedora_messaging/config.py
@@ -283,21 +283,19 @@ import copy
 import logging
 import logging.config
 import os
-import uuid
 
 import pkg_resources
 import toml
 
 from . import exceptions
 
-
 _log = logging.getLogger(__name__)
 
 _fedora_version = pkg_resources.get_distribution("fedora_messaging").version
 _pika_version = pkg_resources.get_distribution("pika").version
 
-# A default, auto-deleted queue for consumers
-_default_queue_name = str(uuid.uuid4())
+# By default, use a server-generated queue name
+_default_queue_name = ""
 
 #: The default configuration settings for fedora-messaging. This should not be
 #: modified and should be copied with :func:`copy.deepcopy`.
@@ -330,7 +328,7 @@ DEFAULTS = dict(
         _default_queue_name: {
             "durable": False,
             "auto_delete": True,
-            "exclusive": False,
+            "exclusive": True,
             "arguments": {},
         }
     },
@@ -383,7 +381,7 @@ def validate_bindings(bindings):
 
     for binding in bindings:
         missing_keys = []
-        for key in ("queue", "exchange", "routing_keys"):
+        for key in ("exchange", "routing_keys"):
             if key not in binding:
                 missing_keys.append(key)
         if missing_keys:

--- a/fedora_messaging/tests/unit/test_cli.py
+++ b/fedora_messaging/tests/unit/test_cli.py
@@ -17,19 +17,19 @@
 """Tests for the :module:`fedora_messaging.cli` module."""
 from __future__ import absolute_import
 
+import errno
 import os
 import unittest
-import errno
 
-from click.testing import CliRunner
-from twisted.internet import error
-from twisted.python import failure
 import click
 import mock
-
+from click.testing import CliRunner
 from fedora_messaging import cli, config, exceptions, message, testing
 from fedora_messaging.tests import FIXTURES_DIR
 from fedora_messaging.twisted import consumer
+
+from twisted.internet import error
+from twisted.python import failure
 
 GOOD_CONF = os.path.join(FIXTURES_DIR, "good_conf.toml")
 BAD_CONF = os.path.join(FIXTURES_DIR, "bad_conf.toml")
@@ -131,9 +131,9 @@ class ConsumeCliTests(unittest.TestCase):
             bindings=[{"exchange": "e", "queue": "qn", "routing_keys": ("rk1", "rk2")}],
             queues={
                 "qn": {
-                    "durable": True,
-                    "auto_delete": False,
-                    "exclusive": False,
+                    "durable": False,
+                    "auto_delete": True,
+                    "exclusive": True,
                     "arguments": {},
                 }
             },
@@ -168,9 +168,9 @@ class ConsumeCliTests(unittest.TestCase):
             ],
             queues={
                 "qn": {
-                    "durable": True,
-                    "auto_delete": False,
-                    "exclusive": False,
+                    "durable": False,
+                    "auto_delete": True,
+                    "exclusive": True,
                     "arguments": {},
                 }
             },

--- a/fedora_messaging/tests/unit/test_config.py
+++ b/fedora_messaging/tests/unit/test_config.py
@@ -19,10 +19,8 @@
 import unittest
 
 import mock
-
 from fedora_messaging import config as msg_config
 from fedora_messaging.exceptions import ConfigurationException
-
 
 full_config = """
 amqp_url = "amqp://guest:guest@rabbit-server1:5672/%2F"
@@ -125,7 +123,6 @@ class ValidateBindingsTests(unittest.TestCase):
             "Configuration error: a binding is missing the following keys",
             str(cm.exception),
         )
-        self.assertIn("queue", str(cm.exception))
         self.assertIn("exchange", str(cm.exception))
         self.assertIn("routing_keys", str(cm.exception))
 

--- a/fedora_messaging/tests/unit/twisted/test_factory.py
+++ b/fedora_messaging/tests/unit/twisted/test_factory.py
@@ -466,7 +466,7 @@ class FactoryV2Tests(unittest.TestCase):
         self.protocol.consume.side_effect = lambda cb, queue: defer.succeed(
             Consumer(queue=queue, callback=cb)
         )
-        bindings = [{"queue": "", "exchange": "amq.topic", "routing_keys": ["#"]}]
+        bindings = [{"exchange": "amq.topic", "routing_keys": ["#"]}]
         expected_bindings = [
             {"queue": declared_queue, "exchange": "amq.topic", "routing_key": "#"}
         ]
@@ -508,7 +508,7 @@ class FactoryV2Tests(unittest.TestCase):
         self.protocol.declare_queue.side_effect = lambda q: queue_new
         # Prepare the mocked existing consumer
         callback = mock.Mock()
-        bindings = [{"queue": "", "exchange": "amq.topic", "routing_key": "#"}]
+        bindings = [{"exchange": "amq.topic", "routing_key": "#"}]
         expected_bindings = [
             {"queue": queue_new, "exchange": "amq.topic", "routing_key": "#"}
         ]

--- a/fedora_messaging/tests/unit/twisted/test_factory.py
+++ b/fedora_messaging/tests/unit/twisted/test_factory.py
@@ -29,6 +29,7 @@ from twisted.python.failure import Failure
 
 from fedora_messaging import config
 from fedora_messaging.twisted.factory import (
+    ConsumerRecord,
     FedoraMessagingFactory,
     FedoraMessagingFactoryV2,
 )

--- a/fedora_messaging/tests/unit/twisted/test_protocol.py
+++ b/fedora_messaging/tests/unit/twisted/test_protocol.py
@@ -35,6 +35,7 @@ from fedora_messaging.exceptions import (
 from fedora_messaging.message import Message
 from fedora_messaging.twisted.protocol import (
     Consumer,
+    ConsumerV2,
     FedoraMessagingProtocol,
     FedoraMessagingProtocolV2,
     _add_timeout,
@@ -581,6 +582,51 @@ class ProtocolV2Tests(unittest.TestCase):
             assert isinstance(failure.value, ConnectionException)
 
         d = proto.consume(lambda x: x, "test_queue")
+        d.addBoth(check)
+        return pytest_twisted.blockon(d)
+
+    def test_consume_existing_consumer(self):
+        """Consuming should re-use an existing consumer if possible."""
+        proto = FedoraMessagingProtocolV2(None)
+        proto._allocate_channel = mock.Mock()
+
+        new_callback = mock.Mock(name="new_callback")
+
+        # Prepare the existing consumer
+        existing_callback = mock.Mock(name="existing_callback")
+        consumer = ConsumerV2(queue="test_queue", callback=existing_callback)
+        proto._consumers["test_queue"] = consumer
+
+        def check(result):
+            self.assertEqual(consumer, result)
+            self.assertEqual(consumer.callback, new_callback)
+            proto._allocate_channel.assert_not_called()
+
+        d = proto.consume(new_callback, "test_queue", consumer)
+        d.addBoth(check)
+        return pytest_twisted.blockon(d)
+
+    def test_consume_provided_consumer(self):
+        """The consume() method must handle being passed a consumer."""
+        proto = FedoraMessagingProtocolV2(None)
+        mock_channel = mock.Mock(name="mock_channel")
+        deferred_channel = defer.succeed(mock_channel)
+        proto._allocate_channel = mock.Mock(return_value=deferred_channel)
+        # Don't go into the read loop
+        proto._read = mock.Mock(retrun_value=defer.succeed(None))
+        # basic_consume() must return a tuple
+        mock_channel.basic_consume.return_value = (mock.Mock(), mock.Mock())
+        # Prepare the consumer
+        callback = mock.Mock()
+        consumer = ConsumerV2(queue="queue_orig", callback=callback)
+
+        def check(result):
+            self.assertEqual(consumer, result)
+            self.assertEqual(consumer.queue, "queue_new")
+            self.assertEqual(consumer._protocol, proto)
+            self.assertEqual(consumer._channel, mock_channel)
+
+        d = proto.consume(callback, "queue_new", consumer)
         d.addBoth(check)
         return pytest_twisted.blockon(d)
 

--- a/fedora_messaging/twisted/consumer.py
+++ b/fedora_messaging/twisted/consumer.py
@@ -80,12 +80,8 @@ class Consumer(object):
         """
         # Remove it from protocol and factory so it doesn't restart later.
         try:
-            del self._protocol._consumers[self.queue]
-        except (KeyError, AttributeError):
-            pass
-        try:
-            del self._protocol.factory._consumers[self.queue]
-        except (KeyError, AttributeError):
+            self._protocol._forget_consumer(self.queue)
+        except AttributeError:
             pass
         # Signal to the _read loop it's time to stop and wait for it to finish
         # with whatever message it might be working on, then wait for the deferred

--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -54,8 +54,6 @@ def _remap_queue_name(bindings, queue_name):
         queue_name (str): The name of the queue to use.
     """
     for binding in bindings:
-        if "queue" not in binding:
-            raise ValueError("Bindings must have a 'queue' key")
         binding["queue"] = queue_name
     # The dicts are changed in-place, don't return anything to make that clear.
 
@@ -508,6 +506,8 @@ class FedoraMessagingFactoryV2(protocol.ReconnectingClientFactory):
                 b = binding.copy()
                 del b["routing_keys"]
                 b["routing_key"] = key
+                if "queue" not in b:
+                    b["queue"] = ""
                 expanded_bindings[b["queue"]].append(b)
 
         expanded_queues = []

--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -509,6 +509,14 @@ class FedoraMessagingFactoryV2(protocol.ReconnectingClientFactory):
             consumer (list of fedora_messaging.api.Consumer): The consumers to cancel.
         """
         for consumer in consumers:
-            del self._consumers[consumer.queue]
+            self._forget_consumer(consumer.queue)
             protocol = yield self.when_connected()
             yield protocol.cancel(consumer)
+
+    def _forget_consumer(self, queue):
+        """Forget about a consumer.
+
+        Args:
+            queue (str): Forget the consumers that consume from this queue.
+        """
+        del self._consumers[queue]

--- a/fedora_messaging/twisted/protocol.py
+++ b/fedora_messaging/twisted/protocol.py
@@ -357,6 +357,8 @@ class FedoraMessagingProtocolV2(TwistedProtocolConnection):
 
         if previous_consumer is not None:
             consumer = previous_consumer
+            # The queue name may have changed, especially in the case of server-generated queues.
+            consumer.queue = queue
         else:
             consumer = ConsumerV2(queue=queue, callback=callback)
         consumer._protocol = self
@@ -550,6 +552,15 @@ class FedoraMessagingProtocolV2(TwistedProtocolConnection):
             except pika.exceptions.AMQPError:
                 pass  # pika doesn't handle repeated closes gracefully
         defer.returnValue(result_queues)
+
+    @defer.inlineCallbacks
+    def declare_queue(self, queue):
+        """
+        Declare a queue. This is a convenience method to call :meth:`declare_queues` with a single
+        argument.
+        """
+        names = yield self.declare_queues([queue])
+        defer.returnValue(names[0])
 
     @defer.inlineCallbacks
     def bind_queues(self, bindings):

--- a/fedora_messaging/twisted/protocol.py
+++ b/fedora_messaging/twisted/protocol.py
@@ -534,19 +534,22 @@ class FedoraMessagingProtocolV2(TwistedProtocolConnection):
                 user does not have permissions to create the object.
         """
         channel = yield self._allocate_channel()
+        result_queues = []
         try:
             for queue in queues:
                 args = queue.copy()
                 args.setdefault("passive", config.conf["passive_declares"])
                 try:
-                    yield channel.queue_declare(**args)
+                    frame = yield channel.queue_declare(**args)
                 except pika.exceptions.ChannelClosed as e:
                     raise BadDeclaration("queue", args, e)
+                result_queues.append(frame.method.queue)
         finally:
             try:
                 channel.close()
             except pika.exceptions.AMQPError:
                 pass  # pika doesn't handle repeated closes gracefully
+        defer.returnValue(result_queues)
 
     @defer.inlineCallbacks
     def bind_queues(self, bindings):

--- a/news/PR239.api
+++ b/news/PR239.api
@@ -1,0 +1,4 @@
+Queues created by the CLI are now non-durable, auto-deleted and exclusive, as
+server-named queues are. It is no longer necessary to declare a queue in the
+configuration file: a server-named queue will be created. Configured bindings
+which do not specify a queue name will be applied to the server-named queue.

--- a/news/PR239.feature
+++ b/news/PR239.feature
@@ -1,0 +1,1 @@
+Support anonymous (server-named) queues.


### PR DESCRIPTION
See https://www.rabbitmq.com/queues.html#server-named-queues

This is an API-breaking change because the queue created by the CLI will not have the same properties as before. They are now mirrored on the anonymous queues: non-durable, auto-deleted and exclusive.

It is no longer necessary to declare a queue in the configuration file: a server-named queue will be created if none is defined. Configured bindings which do not specify a queue name will be applied to the server-named queue.

It's a rather large changeset, so I'm very interested in your opinions, especially from a design standpoint.

Please look at the commits individually for more clarity ;-)