### PR TITLE
providing containerized development environment

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,0 +1,24 @@
+ARG FEDORA_VERSION
+FROM registry.fedoraproject.org/fedora:${FEDORA_VERSION}
+
+WORKDIR /app
+
+RUN dnf upgrade --refresh -y
+
+# Python3 and packages
+RUN dnf install -y python3 python3-pip python3-devel
+
+RUN dnf autoremove -y && dnf clean all -y
+
+# Create aliases for python and pip
+RUN echo 'alias python="python3"' >> ~/.bashrc
+RUN echo 'alias pip="pip3"' >> ~/.bashrc
+
+COPY . .
+
+# Pip installations
+RUN pip install -r /app/dev-requirements.txt
+RUN pip install -r /app/requirements.txt
+
+CMD ["sh","-c", "pip3 install -e /app && tail -f /dev/null"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+_CHECK_PODMAN := $(shell command -v podman 2> /dev/null)
+define compose-tool
+	$(if $(_CHECK_PODMAN), podman-compose, docker-compose) -f container-compose.yml
+endef
+
+define container-tool
+	$(if $(_CHECK_PODMAN), podman, docker)
+endef
+
+up:
+	$(call compose-tool) up -d
+restart:
+	$(MAKE) halt && $(MAKE) up
+halt:
+	$(call compose-tool) down -t1
+bash:
+	$(call container-tool) exec -it fedora-msg bash -c "bash;"
+logs:
+	$(call container-tool) logs -f fedora-msg rabbitmq

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -1,0 +1,33 @@
+version: "2.0"
+
+services:
+  fedora-msg:
+    image: fedora-msg-base
+    build:
+      context: .
+      dockerfile: Containerfile.dev
+      args:
+        FEDORA_VERSION: 34
+    container_name: "fedora-msg"
+    network_mode: host
+    volumes:
+      - ./:/app:z
+    privileged: true
+    restart: unless-stopped
+    depends_on:
+      rabbitmq:
+        condition: service_started
+
+  rabbitmq:
+    image: docker.io/library/rabbitmq:3.8.16-management-alpine
+    container_name: "rabbitmq"
+    network_mode: host
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "5672" ]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest

--- a/news/241.dev
+++ b/news/241.dev
@@ -1,0 +1,1 @@
+Containerized environment provided for both docker and podman.


### PR DESCRIPTION
Provides containerized development environment.
Compatible with docker and podman.

Available make commands:

- up: starts the containers for fedora-messaging and rabbitmq
- restart: restarts the containers if currently running
- halt: stops the containers
- bash: enters inside the fedora-messaing container via terminal. So you can code outside the container, and start/stop/test the python application from inside the container.
- logs: tracks container logs