### PR TITLE
Add upstream version format

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,7 @@ files_to_sync:
 upstream_package_name: fedora-messaging
 # downstream (Fedora) RPM package name
 downstream_package_name: fedora-messaging
+upstream_tag_template: v{version}
 
 # dependencies needed to prepare for and build the source RPM
 srpm_build_deps:


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

Should allow for tags to have a v prefix, much unlike the https://github.com/fedora-infra/fedora-messaging/releases/tag/3.0.2 which does not seem to have one.