### PR TITLE
Use tomllib from the standard library on Python 3.11

### DIFF
--- a/fedora_messaging/config.py
+++ b/fedora_messaging/config.py
@@ -285,7 +285,12 @@ import logging.config
 import os
 
 import pkg_resources
-import toml
+
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 from . import exceptions
 
@@ -521,15 +526,13 @@ class LazyConfig(dict):
 
         if os.path.exists(config_path):
             _log.info(f"Loading configuration from {config_path}")
-            with open(config_path) as fd:
+            with open(config_path, "rb") as fd:
                 try:
-                    file_config = toml.load(fd)
+                    file_config = tomllib.load(fd)
                     for key in file_config:
                         config[key.lower()] = file_config[key]
-                except toml.TomlDecodeError as e:
-                    msg = "Failed to parse {}: error at line {}, column {}: {}".format(
-                        config_path, e.lineno, e.colno, e.msg
-                    )
+                except tomllib.TOMLDecodeError as e:
+                    msg = f"Failed to parse {config_path}: {e}"
                     raise exceptions.ConfigurationException(msg)
         else:
             _log.info(f"The configuration file, {config_path}, does not exist.")

--- a/fedora_messaging/tests/unit/test_cli.py
+++ b/fedora_messaging/tests/unit/test_cli.py
@@ -97,7 +97,7 @@ class ConsumeCliTests(TestCase):
         """Assert a bad configuration file is reported."""
         expected_err = (
             "Error: Invalid value: Configuration error: Failed to parse"
-            " {}: error at line 1, column 1".format(BAD_CONF)
+            " {}: Invalid value (at line 1, column 20)".format(BAD_CONF)
         )
         result = self.runner.invoke(cli.cli, ["--conf=" + BAD_CONF, "consume"])
         self.assertEqual(2, result.exit_code)

--- a/fedora_messaging/tests/unit/test_config.py
+++ b/fedora_messaging/tests/unit/test_config.py
@@ -22,7 +22,7 @@ from fedora_messaging import config as msg_config
 from fedora_messaging.exceptions import ConfigurationException
 
 
-full_config = """
+full_config = b"""
 amqp_url = "amqp://guest:guest@rabbit-server1:5672/%2F"
 
 publish_exchange = "special_exchange"
@@ -83,9 +83,9 @@ handlers = ["console"]
 level = "DEBUG"
 handlers = ["console"]
 """
-empty_config = '# publish_exchange = "special_exchange"'
-partial_config = 'publish_exchange = "special_exchange"'
-malformed_config = 'publish_exchange = "special_exchange'  # missing close quote
+empty_config = b'# publish_exchange = "special_exchange"'
+partial_config = b'publish_exchange = "special_exchange"'
+malformed_config = b'publish_exchange = "special_exchange'  # missing close quote
 
 
 class TestObj:
@@ -209,7 +209,7 @@ class LoadTests(TestCase):
         )
 
     @mock.patch(
-        "fedora_messaging.config.open", mock.mock_open(read_data='bad_key = "val"')
+        "fedora_messaging.config.open", mock.mock_open(read_data=b'bad_key = "val"')
     )
     @mock.patch("fedora_messaging.config.os.path.exists", return_value=True)
     def test_override_client_props(self, mock_exists):
@@ -218,13 +218,13 @@ class LoadTests(TestCase):
         for key in ("version", "information", "product"):
             with mock.patch(
                 "fedora_messaging.config.open",
-                mock.mock_open(read_data=conf.format(key)),
+                mock.mock_open(read_data=conf.format(key).encode("utf-8")),
             ):
                 config = msg_config.LazyConfig()
                 self.assertRaises(ConfigurationException, config.load_config)
 
     @mock.patch(
-        "fedora_messaging.config.open", mock.mock_open(read_data='bad_key = "val"')
+        "fedora_messaging.config.open", mock.mock_open(read_data=b'bad_key = "val"')
     )
     @mock.patch("fedora_messaging.config.os.path.exists", return_value=True)
     def test_invalid_key(self, mock_exists):
@@ -232,17 +232,19 @@ class LoadTests(TestCase):
         config = msg_config.LazyConfig()
         self.assertRaises(ConfigurationException, config.load_config)
 
-    @mock.patch("fedora_messaging.config.open", mock.mock_open(read_data="Ni!"))
+    @mock.patch("fedora_messaging.config.open", mock.mock_open(read_data=b"Ni!"))
     @mock.patch("fedora_messaging.config.os.path.exists", return_value=True)
     def test_bad_config_file(self, mock_exists):
         """Assert an invalid TOML file raises a ConfigurationException."""
         with self.assertRaises(ConfigurationException) as cm:
             msg_config.LazyConfig().load_config()
         error = (
-            "Failed to parse /etc/fedora-messaging/config.toml: error at line 1, column 3: "
-            "Found invalid character in key name: '!'. Try quoting the key name."
+            "Failed to parse /etc/fedora-messaging/config.toml: "
+            "Expected '=' after a key in a key/value pair (at line 1, column 3)"
         )
-        self.assertEqual(error, cm.exception.message)
+        # older tomli version used in Python 3.6 uses double-quotes
+        error_old = error.replace("'", '"')
+        self.assertIn(cm.exception.message, (error, error_old))
 
     @mock.patch(
         "fedora_messaging.config.open", mock.mock_open(read_data=partial_config)

--- a/news/PR274.other
+++ b/news/PR274.other
@@ -1,0 +1,2 @@
+Use tomllib from the standard library on Python 3.11 and above,
+fallback to tomli otherwise.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ blinker
 click
 crochet
 jsonschema
-toml
+tomli;python_version<"3.11"
 Twisted
 pytz
 PyOpenSSL


### PR DESCRIPTION
The code would be slightly easier if we fell back to tomli, but I kept using toml as this code also targets EL 8.

See https://fedoraproject.org/wiki/Changes/DeprecatePythonToml