### PR TITLE
Don't run integration tests on Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           RABBITMQ_TAG: "3-management-alpine"
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox
@@ -71,7 +71,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'


### PR DESCRIPTION
Python 3.6 does not seem to be supported by the github action anymore. It's fine, we don't need to run the integration tests on all versions of python, only those that we have in production.