### PR TITLE
feat: Add asyncio support to publish function

### DIFF
--- a/fedora_messaging/api.py
+++ b/fedora_messaging/api.py
@@ -3,6 +3,7 @@
 
 import inspect
 import logging
+import asyncio
 
 import crochet
 from twisted.internet import defer, reactor
@@ -310,17 +311,20 @@ def publish(message, exchange=None, timeout=30):
         exchange = config.conf["publish_exchange"]
 
     eventual_result = _twisted_publish(message, exchange)
-    try:
-        eventual_result.wait(timeout=timeout)
-        publish_signal.send(publish, message=message)
-    except crochet.TimeoutError:
-        eventual_result.cancel()
-        wrapper = exceptions.PublishTimeout(
-            f"Publishing timed out after waiting {timeout} seconds."
-        )
-        publish_failed_signal.send(publish, message=message, reason=wrapper)
-        raise wrapper
-    except Exception as e:
-        _log.error(eventual_result.original_failure().getTraceback())
-        publish_failed_signal.send(publish, message=message, reason=e)
-        raise
+    async def wait_for_result():
+        try:
+            await asyncio.wait_for_result(eventual_result, timeout=timeout)
+            publish_signal.send(publish, message=message)
+        except asyncio.TimeoutError:
+            eventual_result.cancel()
+            wrapper = exceptions.PublishTimeout(
+                f"Publishing timed out after waiting {timeout} seconds."
+            )
+            publish_failed_signal.send(publish, message=message, reason=wrapper)
+            raise wrapper
+        except Exception as e:
+            _log.error(eventual_result.original_failure().getTraceback())
+            publish_failed_signal.send(publish, message=message, reason=e)
+            raise
+
+    asyncio.run(wait_for_result())


### PR DESCRIPTION
This pull request addresses issue #303 

Changes Made:
- Added support for asynchronous programming using asyncio to the `publish function`.
- Utitlized async await syntax to make the function asynchronous.
- Introduced error handling for asyncio.TimeoutError to handle timeouts.

Related Issue:
Issue #303 

Please review and provide feedback. Thank you!