### PR TITLE
Fixes documentation issue #245

### DIFF
--- a/docs/user-guide/quick-start.rst
+++ b/docs/user-guide/quick-start.rst
@@ -145,3 +145,8 @@ Connecting the Fedora's private virtual host requires working with the Fedora
 infrastructure team. The current process and configuration for this is
 documented in the `infrastructure team's development guide
 <https://docs.fedoraproject.org/en-US/infra/developer_guide/messaging/>`_.
+
+**Note:** It is essential to configure the ``passive_declares`` option
+correctly in the ``/etc/fedora-messaging/config.toml`` file. This setting is
+is mandatory for users of Fedora's ``/pubsub`` vhost and should be set to
+``true``. It controls the declaration of queues and exchanges.


### PR DESCRIPTION
# Summary

Fixes #245

This pull request aims to improve the documentation for configuring Fedora Messaging by adding a reminder regarding the `passive_declares` option to be set to true.

## Changes Made

- Added a reminder note to the quick-start.rst file emphasizing the importance of setting `passive_declares` to true in the Fedora Messaging configuration.
- Provided clear instructions for users to locate the `config.toml` file and set the `passive_declares` option.

## Purpose

By enhancing the documentation with this reminder, we aim to reduce potential issues for users of Fedora's /pubsub vhost who might forget to configure `passive_declares`. Ensuring that `passive_declares` is correctly set to true is essential for proper functioning of queues and exchanges in Fedora Messaging.
