### PR TITLE
Improving 'id' schema documentation

### DIFF
--- a/docs/tutorial/schemas.rst
+++ b/docs/tutorial/schemas.rst
@@ -57,8 +57,10 @@ Schema format
 This dictionary describes the possible keys and types in the JSON object being
 validated, using the following reserved keys:
 
-- ``id`` (or ``$id``): an URI identifing this schema. Change the last part of
-  the example URL to use your app's name.
+- ``id`` (or ``$id``): an URI identifing this schema. This URI is used to
+  differentiate between different schema packages and should ideally remain
+  consistent within a specific schema package. Change the last part of the
+  example URL to use your app’s name.
 - ``$schema``: an URI describing the validator to use, you can leave that one
   as it is. It is only present at the root of the dictionary.
 - ``description``: a fulltext description of the key.


### PR DESCRIPTION
## Summary:

Fixes #220
This PR updates the documentation to provide clarity on the usage of the `id` (or `$id`) field in message schemas within Fedora Messaging. 


## Description:

This PR updates the documentation to provide clarity on the usage of the `id` (or `$id`) field in message schemas within Fedora Messaging. The `id` field serves as a URI identifier for each schema, distinguishing between different schema packages. It is important to maintain consistency within a specific schema package while ensuring uniqueness across packages.

### Changes Made:

Updated the documentation to emphasize the purpose and significance of the `id` field in message schemas.