### PR TITLE
Add back api._twisted_publish with deprecation warning

### DIFF
--- a/fedora_messaging/api.py
+++ b/fedora_messaging/api.py
@@ -2,6 +2,7 @@
 
 import inspect
 import logging
+import warnings
 
 import crochet
 from twisted.internet import defer, reactor, threads
@@ -260,6 +261,16 @@ def twisted_publish(message, exchange=None):
     except Exception as e:
         yield threads.deferToThread(publish_failed_signal.send, publish, message=message, reason=e)
         raise
+
+
+def _twisted_publish(message, exchange):
+    """Deprecated method, use _twisted_publish_wrapper()."""
+    warnings.warn(
+        "_twisted_publish() is deprecated, use _twisted_publish_wrapper(); version 3.6.0",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _twisted_publish_wrapper(message, exchange)
 
 
 @crochet.run_in_reactor

--- a/news/PR375.api
+++ b/news/PR375.api
@@ -1,0 +1,1 @@
+Add back api._twisted_publish as deprecated method and emit proper warning when it is used

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -222,6 +222,22 @@ class TestTwistedPublishWrapper:
 
         mock_twisted_publish.assert_called_once_with(message, exchange)
 
+    @mock.patch("warnings.warn")
+    def test_deprecated_twisted_publish(self, warn):
+        """Assert calling the deprecated method emits warning."""
+        message = "test_message"
+        exchange = "test_exchange"
+
+        with mock.patch("fedora_messaging.api._twisted_publish_wrapper") as mock_twisted_publish:
+            api._twisted_publish(message, exchange)
+
+        warn.assert_called_once_with(
+            "_twisted_publish() is deprecated, use _twisted_publish_wrapper(); version 3.6.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        mock_twisted_publish.assert_called_once_with(message, exchange)
+
     @pytest_twisted.inlineCallbacks
     def test_publish_failed(self):
         """Assert an exception is raised when message can't be published."""


### PR DESCRIPTION
`api._twisted_publish` is (was) used for mocking tests.
The removal of that method in 3.6.0 without previous warnings broke Bodhi tests (and I think other dependent packages too). The removal should be handled by provide a proper warning when the method is used and wait a decent amount of time before complete removal.

This PR adds back the deprecated method, which just emits a deprecation notice and routes to the new method, which seems 1:1 compatible.
I just don't know if the decorators should be applied to the deprecated method as well.