### PR TITLE
Add an embedded HTTP server to monitor the service

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -40,6 +40,10 @@ example_key = "for my consumer"
 prefetch_size = 0
 prefetch_count = 25
 
+# [monitoring]
+# Set this if you want to enable HTTP-based monitoring of the service
+# port = 8070
+
 [log_config]
 version = 1
 disable_existing_loggers = true

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -129,8 +129,8 @@ SERIALIZED_MESSAGE_SCHEMA
 .. autodata:: fedora_messaging.message.SERIALIZED_MESSAGE_SCHEMA
 
 
-Utilities
-=========
+Schema Utilities
+================
 
 .. automodule:: fedora_messaging.schema_utils
 

--- a/docs/user-guide/consuming.rst
+++ b/docs/user-guide/consuming.rst
@@ -197,6 +197,42 @@ consumers to use if they need configuration options. Refer to the
 :ref:`conf-consumer-config` in the Configuration documentation for details.
 
 
+Monitoring
+==========
+
+A Fedora Messaging consumer can start a dedicated HTTP server to let users
+monitor its state. You can configure the port in the configuration file under
+the ``[monitoring]`` section, with ``address`` and ``port``.
+If the section is empty, the monitoring service will be disabled.
+The default value for ``address`` is an empty string, which means that the
+monitoring server will listen on all interfaces.
+There is no default value for ``port``, you will have to choose a port.
+
+When a consumer is running with the monitoring server enabled, you can get the
+following data::
+
+    $ curl http://localhost:8070/live
+    {"status": "OK"}
+
+    $ curl http://localhost:8070/ready
+    {"consuming": true, "published": 0, "consumed": {"received": 0, "processed": 0, "dropped": 0, "rejected": 0, "failed": 0}}
+
+The ``/live`` endpoint always returns the same JSON data.
+The statistics in the ``/ready`` endpoint are gathered from the start of the
+service. They mean:
+
+- ``consuming``: whether the consumer is running or not.
+- ``published``: amount of messages published on the bus.
+- ``consumed.received``: amount of messages received from the bus.
+- ``consumer.processed``: amount of messages successfully processed by the consumer
+- ``consumer.dropped``: amount of messages dropped by the consumer (by raising the
+  :class:`fedora_messaging.exceptions.Drop` exception).
+- ``consumer.rejected``: amount of messages rejected by the consumer (by raising the
+  :class:`fedora_messaging.exceptions.Nack` exception). Those messages were put
+  back in the queue.
+- ``consumer.failed``: amount of message that caused another exception to be raised.
+
+
 systemd Service
 ===============
 

--- a/fedora_messaging/twisted/monitor.py
+++ b/fedora_messaging/twisted/monitor.py
@@ -1,0 +1,110 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+A Twisted HTTP service to monitor a Fedora Messaging Service.
+
+This module provides a HTTP service that can be used to implement health checks in OpenShift, as
+described here: https://docs.openshift.com/container-platform/4.16/applications/application-health.html
+
+The webserver will listen on the port set in the configuration file, and provides two endpoints that
+return JSON data:
+- `/live` to check when the program is up
+- `/ready` to check when the consumer is connected, and get the statistics
+"""
+
+import abc
+import json
+import typing
+
+from twisted.application.internet import TCPServer
+from twisted.web import resource, server
+
+
+if typing.TYPE_CHECKING:
+    from .service import FedoraMessagingServiceV2
+
+
+class FMServiceResource(resource.Resource, metaclass=abc.ABCMeta):
+    """An abstract class for service-monitoring endpoints."""
+
+    def __init__(self, *args, **kwargs):
+        self._fm_service = kwargs.pop("fm_service")
+        super().__init__(*args, **kwargs)
+
+    @abc.abstractmethod
+    def _get_response(self) -> dict:
+        """Return the response as a dictionary."""
+        raise NotImplementedError
+
+    def render_GET(self, request):
+        request.setHeader("Content-Type", "application/json ")
+        return json.dumps(self._get_response()).encode("utf-8") + b"\n"
+
+
+class Live(FMServiceResource):
+    """The `/live` endpoint, returns JSON"""
+
+    isLeaf = True
+
+    def _get_response(self):
+        return {"status": "OK"}
+
+
+class Ready(FMServiceResource):
+    """The `/ready` endpoint
+
+    Returns the consumer state and some statistics about messages consumed and produced in
+    JSON format.
+    """
+
+    isLeaf = True
+
+    def _get_response(self):
+        response = {"consuming": self._fm_service.consuming}
+        response.update(self._fm_service.stats.as_dict())
+        return response
+
+
+class MonitoringSite(server.Site):
+    """A subclass of Twisted's site to redefine its name in the logs."""
+
+    def logPrefix(self):
+        return "Monitoring HTTP server"
+
+
+def monitor_service(
+    fm_service: "FedoraMessagingServiceV2", *, address: str, port: int
+) -> TCPServer:
+    """Add the Twisted service for HTTP-based monitoring to the provided Fedora Messaging Service.
+
+    Args:
+        fm_service: the service to monitor
+        address: the IP address to listen on
+        port: the TCP port to listen on
+
+    Returns:
+        The monitoring service
+    """
+    root = resource.Resource()
+    root.putChild(b"live", Live(fm_service=fm_service))
+    root.putChild(b"ready", Ready(fm_service=fm_service))
+    site = MonitoringSite(root)
+    monitor_service = TCPServer(port, site, interface=address)
+    monitor_service.setName("monitoring")
+    monitor_service.setServiceParent(fm_service)
+    return monitor_service

--- a/fedora_messaging/twisted/service.py
+++ b/fedora_messaging/twisted/service.py
@@ -98,6 +98,14 @@ class FedoraMessagingServiceV2(service.MultiService):
         yield self._service.factory.stopFactory()
         yield service.MultiService.stopService(self)
 
+    @property
+    def stats(self):
+        return self._service.factory.stats
+
+    @property
+    def consuming(self):
+        return self._service.factory.consuming
+
 
 def _configure_tls_parameters(parameters):
     """

--- a/fedora_messaging/twisted/stats.py
+++ b/fedora_messaging/twisted/stats.py
@@ -1,0 +1,85 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Datastructures to store consumer and producer statistics.
+"""
+
+
+from typing import Any
+
+
+class Statistics:
+    """A datastructure to manager integers as attributes."""
+
+    names = []
+
+    def __init__(self):
+        for name in self.names:
+            setattr(self, name, 0)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name not in self.names:
+            raise AttributeError(
+                f"{self.__class__.__name__} does not have a {name} attribute. "
+                f"Available attributes: {', '.join(sorted(self.names))}."
+            )
+        return super().__setattr__(name, value)
+
+    def __add__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"{self.__class__.__name__} instances can only be added to other "
+                f"{self.__class__.__name__} instances."
+            )
+        new_stats = self.__class__()
+        for name in self.names:
+            setattr(new_stats, name, getattr(self, name) + getattr(other, name))
+        return new_stats
+
+    def as_dict(self):
+        return {name: getattr(self, name) for name in self.names}
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.as_dict()}>"
+
+
+class ConsumerStatistics(Statistics):
+    """Statistics for a :class:`Consumer`."""
+
+    names = (
+        "received",
+        "processed",
+        "dropped",
+        "rejected",
+        "failed",
+    )
+
+
+class FactoryStatistics(Statistics):
+    """Statistics for a :class:`FedoraMessagingFactoryV2`."""
+
+    names = ("published", "consumed")
+
+    def __init__(self):
+        super().__init__()
+        self.consumed = ConsumerStatistics()
+
+    def as_dict(self):
+        d = super().as_dict()
+        d["consumed"] = self.consumed.as_dict()
+        return d

--- a/news/380.feature
+++ b/news/380.feature
@@ -1,0 +1,1 @@
+Add an embedded HTTP server to monitor the service, see the "Monitoring" section in <project:./user-guide/consuming.rst>

--- a/tests/unit/twisted/test_factory.py
+++ b/tests/unit/twisted/test_factory.py
@@ -169,6 +169,7 @@ class TestFactoryV2:
 
         def _check(publish_result):
             self.protocol.publish.assert_called_once_with(message, exchange)
+            assert self.factory.stats.published == 1
 
         d.addCallback(_publish)
         d.addCallback(_check)
@@ -211,6 +212,20 @@ class TestFactoryV2:
             self.protocol.declare_queue.assert_called_once_with(queue_config)
             self.protocol.bind_queues.assert_called_once_with(expected_bindings)
             self.protocol.consume.assert_called_once_with(callback, declared_queue)
+
+            assert self.factory.consuming is False
+            consumer._running = True
+            assert self.factory.consuming is True
+            assert self.factory.stats.as_dict() == {
+                "published": 0,
+                "consumed": {
+                    "received": 0,
+                    "processed": 0,
+                    "dropped": 0,
+                    "rejected": 0,
+                    "failed": 0,
+                },
+            }
 
         d.addCallback(_consume)
         d.addCallback(_check)

--- a/tests/unit/twisted/test_monitor.py
+++ b/tests/unit/twisted/test_monitor.py
@@ -1,0 +1,70 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import pytest
+from twisted.application.service import MultiService
+from twisted.web.client import Agent, readBody
+
+from fedora_messaging.twisted.monitor import monitor_service
+from fedora_messaging.twisted.stats import ConsumerStatistics
+
+
+try:
+    import pytest_twisted
+except ImportError:
+    pytest.skip("pytest-twisted is missing, skipping tests", allow_module_level=True)
+
+
+@pytest.fixture
+def service(available_port):
+    srv = MultiService()
+    monitor_service(srv, address="127.0.0.1", port=available_port)
+    srv.startService()
+    yield srv
+    srv.stopService()
+
+
+@pytest.fixture
+def client():
+    from twisted.internet import reactor
+
+    return Agent(reactor)
+
+
+class TestMonitorService:
+
+    @pytest_twisted.inlineCallbacks
+    def test_liveness(self, available_port, service, client):
+        response = yield client.request(
+            b"GET", f"http://localhost:{available_port}/live".encode("ascii")
+        )
+        body = yield readBody(response)
+        assert body == b'{"status": "OK"}\n'
+
+    @pytest_twisted.inlineCallbacks
+    def test_readiness(self, available_port, service, client):
+        service.consuming = True
+        service.stats = ConsumerStatistics()
+        service.stats.received = 42
+        response = yield client.request(
+            b"GET", f"http://localhost:{available_port}/ready".encode("ascii")
+        )
+        body = yield readBody(response)
+        assert body == (
+            b'{"consuming": true, "received": 42, "processed": 0, "dropped": 0, "rejected": 0, '
+            b'"failed": 0}\n'
+        )

--- a/tests/unit/twisted/test_stats.py
+++ b/tests/unit/twisted/test_stats.py
@@ -1,0 +1,61 @@
+# This file is part of fedora_messaging.
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import pytest
+
+from fedora_messaging.twisted.stats import ConsumerStatistics
+
+
+def test_repr():
+    expected = "<ConsumerStatistics {'received': 0, 'processed': 0, 'dropped': 0, 'rejected': 0, 'failed': 0}>"
+    assert repr(ConsumerStatistics()) == expected
+    assert str(ConsumerStatistics()) == expected
+
+
+def test_stats_add():
+    stats_1 = ConsumerStatistics()
+    stats_1.received = 42
+    stats_1.processed = 43
+    stats_2 = ConsumerStatistics()
+    stats_2.received = 1
+    stats_2.processed = 2
+    stats_2.dropped = 10
+    combined = stats_1 + stats_2
+    assert combined.as_dict() == {
+        "received": 43,
+        "processed": 45,
+        "dropped": 10,
+        "rejected": 0,
+        "failed": 0,
+    }
+
+
+def test_stats_add_bad_type():
+    with pytest.raises(TypeError) as handler:
+        ConsumerStatistics() + 42
+    assert str(handler.value) == (
+        "ConsumerStatistics instances can only be added to other ConsumerStatistics instances."
+    )
+
+
+def test_stats_bad_attr():
+    with pytest.raises(AttributeError) as handler:
+        ConsumerStatistics().dummy = 42
+    assert str(handler.value) == (
+        "ConsumerStatistics does not have a dummy attribute. Available attributes: dropped, "
+        "failed, processed, received, rejected."
+    )


### PR DESCRIPTION
This changeset adds an embedded HTTP server to monitor consumers and producers, and get statistics about activity.

Fixes: #380 