### PR TITLE
Handle acknowledgement timeouts in the consumer

### DIFF
--- a/fedora_messaging/twisted/consumer.py
+++ b/fedora_messaging/twisted/consumer.py
@@ -291,7 +291,7 @@ class Consumer:
                 self.cancel()
             else:
                 _std_log.exception(
-                    "Consumer halted (%r) unexpectedly; " "the connection should restart.",
+                    "Consumer halted (%r) unexpectedly; the connection should restart.",
                     failure,
                 )
         elif failure.check(error.ConnectionDone, error.ConnectionLost):
@@ -300,6 +300,14 @@ class Consumer:
                 "the connection should restart and consuming will resume.",
                 failure.value,
             )
+        elif failure.check(pika.exceptions.ChannelWrongStateError):
+            _std_log.warning(
+                "The channel was closed by the server, you may have to increase the "
+                "consumer_timeout configuration on RabbitMQ and/or decrease qos.prefetch_count "
+                "in the fedora-messaging configuration file. Consuming will resume, starting "
+                "with the last processed message again."
+            )
+            self._restart_consuming()
         elif failure.check(pika.exceptions.AMQPError):
             _std_log.exception(
                 "An unexpected AMQP error occurred; the connection should "
@@ -308,6 +316,13 @@ class Consumer:
         else:
             self.result.errback(failure)
             self.cancel()
+
+    @defer.inlineCallbacks
+    def _restart_consuming(self):
+        if self._protocol is None:  # pragma: no cover
+            return
+        self._channel = yield self._protocol._allocate_channel()
+        yield self.consume()
 
     @defer.inlineCallbacks
     def cancel(self) -> Generator[defer.Deferred[Any], Any]:

--- a/news/+ack-timeout.feature.md
+++ b/news/+ack-timeout.feature.md
@@ -1,0 +1,1 @@
+Handle [acknowledgement timeouts](https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout) in the consumer

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -504,6 +504,84 @@ def test_twisted_consume_serverside_cancel(queue_and_binding):
         pytest.fail("Timeout reached without consumer calling its errback!")
 
 
+@pytest.fixture
+def consumer_timeout():
+    # queues, bindings = queue_and_binding
+    # queue_name = next(iter(queues.keys()))
+
+    # Set consumer acknowledgement timeout to 1s
+    body = {
+        "policies": [
+            {
+                "vhost": "/",
+                "name": "consumer_timeout",
+                "pattern": ".*",
+                "apply-to": "queues",
+                "definition": {
+                    "consumer-timeout": 1000,
+                },
+                "priority": 0,
+            }
+        ]
+    }
+    d_response = treq.post(f"{HTTP_API}definitions/%2F/", json=body, auth=HTTP_AUTH, timeout=3)
+    response = pytest_twisted.blockon(d_response)
+    assert response.code == 204
+    yield
+    d_response = treq.delete(f"{HTTP_API}policies/%2F/consumer_timeout", auth=HTTP_AUTH, timeout=3)
+    response = pytest_twisted.blockon(d_response)
+    assert response.code == 204
+
+
+@pytest_twisted.inlineCallbacks
+def test_twisted_consume_consumer_timeout(consumer_timeout, queue_and_binding, caplog):
+    """Check that the consumer handles acknowledgement timeouts.
+
+    See: https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout
+    """
+    queues, bindings = queue_and_binding
+
+    msg = message.Message(
+        topic="nice.message",
+        headers={"niceness": "very"},
+        body={"encouragement": "You're doing great!"},
+    )
+    messages_received = []
+
+    def callback(message):
+        """Wait a few seconds on each message, quit on the 2nd."""
+        messages_received.append(message)
+        if len(messages_received) == 1:
+            # Unfortunately the timeout is evaluated server-side at 1 minute intervals :-(
+            time.sleep(70)
+        else:
+            raise exceptions.HaltConsumer()
+
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+
+    # Wait for a message to get through, and then send
+    # the second and wait for the consumer to finish
+    yield threads.deferToThread(api.publish, msg, "amq.topic")
+    yield threads.deferToThread(api.publish, msg, "amq.topic")
+
+    # Delete the queue and assert the consumer errbacks
+    # consumers[0].result.addTimeout(10, reactor)
+    consumers[0].result.addTimeout(80, reactor)
+    try:
+        yield consumers[0].result
+        pytest.fail("Consumer did not errback!")
+    except (defer.TimeoutError, defer.CancelledError):
+        pytest.fail("Timeout reached without consumer stopping!")
+    except exceptions.HaltConsumer as e:
+        assert len(messages_received) == 2
+        assert e.exit_code == 0
+    fm_logs = [r for r in caplog.records if r.name.startswith("fedora_messaging.")]
+    assert len(fm_logs) == 1
+    assert fm_logs[0].levelname == "WARNING"
+    assert fm_logs[0].message.startswith("The channel was closed by the server, ")
+    assert "Consuming will resume" in fm_logs[0].message
+
+
 @pytest_twisted.inlineCallbacks
 def test_no_vhost_permissions(admin_user, queue_and_binding):
     """Assert a hint is given if the user doesn't have any access to the vhost"""

--- a/tests/unit/twisted/test_consumer.py
+++ b/tests/unit/twisted/test_consumer.py
@@ -10,6 +10,7 @@ import pika
 import pika.exceptions
 import pytest
 from twisted.internet import defer, error
+from twisted.python.failure import Failure
 
 from fedora_messaging.exceptions import (
     ConnectionException,
@@ -372,6 +373,64 @@ class TestConsumer:
         assert self.consumer.result.called is True
         self.consumer.result.addErrback(lambda f: f.check(ConsumerCanceled))
         yield self.consumer.result
+
+    @pytest_twisted.inlineCallbacks
+    def test_exit_loop_channel_wrong_state(self, mocker):
+        """Check that the consumer handles acknowledgement timeouts.
+
+        See: https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout
+        """
+        log = mocker.patch("fedora_messaging.twisted.consumer._std_log")
+        # Stop after the second message
+        self.callback.side_effect = [lambda m: None, HaltConsumer()]
+        # Fail acknowledging after the first message, succeed on the second
+        self.channel.basic_ack.side_effect = [
+            pika.exceptions.ChannelWrongStateError("Channel is closed"),
+            lambda *args, **kwargs: None,
+        ]
+        queue = Mock()
+        queue.get.side_effect = lambda: defer.succeed(
+            (
+                self.channel,
+                MockDeliveryFrame("dt", "rk"),
+                MockProperties(),
+                json.dumps({"content": "foobar"}).encode("ascii"),
+            )
+        )
+        self.channel.queue_object = queue
+        yield self.consumer.consume()
+        yield self.consumer._read_loop
+
+        # A new channel should have been allocated
+        self.protocol.channel.assert_called_once_with()
+        # Consumption should have been required twice
+        assert self.channel.basic_consume.call_count == 2
+
+        # It should have restarted, wait for the 2nd read loop
+        yield self.consumer._read_loop
+
+        # The queue should have been fetched twice
+        assert queue.get.call_count == 2
+        # Callback should have been called twice
+        assert self.callback.call_count == 2
+        for call in self.callback.call_args_list:
+            assert call.args[0].body == {"content": "foobar"}
+        # Acknowledgement should have happened twice
+        assert self.channel.basic_ack.call_count == 2
+        for call in self.channel.basic_ack.call_args_list:
+            assert call.kwargs == dict(delivery_tag="dt")
+        # The AMQP error should have been handled
+        log.exception.assert_not_called()
+        log.warning.assert_called()
+        logmsg = log.warning.call_args[0][0]
+        assert "The channel was closed by the server" in logmsg
+        assert "Consuming will resume" in logmsg
+        # On 2nd try, HaltConsumer should have been raised and the consumer should be done.
+        assert self.consumer.result.called is True
+        assert isinstance(self.consumer.result.result, Failure)
+        assert isinstance(self.consumer.result.result.value, HaltConsumer)
+        # It was a temporary error, no canceling
+        self.channel.basic_cancel.assert_not_called()
 
     @pytest_twisted.inlineCallbacks
     def test_exit_loop_amqp_error(self, mocker):


### PR DESCRIPTION
See: https://www.rabbitmq.com/docs/consumers#acknowledgement-timeout

This has been reported in the `robosignatory` queues since the Fedora datacenter move.

If acknowledgement fails, the consumer will restart and the last message will be processed again.