### PR TITLE
Install a new event loop explicitly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
           - py311-unittest
           - py312-unittest
           - py313-unittest
+          - py314-unittest
 
   integration-tests:
     name: Integration tests
@@ -106,6 +107,7 @@ jobs:
           - py311-integration
           - py312-integration
           - py313-integration
+          - py314-integration
 
 
   # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

--- a/fedora_messaging/cli.py
+++ b/fedora_messaging/cli.py
@@ -8,6 +8,7 @@ The ``fedora-messaging`` `Click`_ CLI.
 .. _Click: http://click.pocoo.org/
 """
 
+import asyncio
 import errno
 import importlib
 import logging
@@ -26,7 +27,10 @@ from fedora_messaging import message
 
 
 try:
-    asyncioreactor.install()
+    # Twisted 25.5 does not support Python 3.14, and at the time of this writing neither
+    # does pytest-twisted. This is because Python removed a number of APIs in asyncio. This
+    # is a temporary workaround because they plan to remove these APIs too.
+    asyncioreactor.install(asyncio.new_event_loop())
 except error.ReactorAlreadyInstalledError:
     # The tests install a reactor before importing this module
     from twisted.internet import reactor

--- a/news/531.bug
+++ b/news/531.bug
@@ -1,0 +1,1 @@
+Explicitly install an event loop to support Python 3.14, which no longer does so implicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ]
 keywords = ["fedora"]
 packages = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,25 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+import asyncio
 import os
 
 import crochet
 import pytest
 
 from .utils import get_available_port
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config):
+    """
+    Short-term fix to support Python 3.14.
+
+    Twisted 25.5 does not support Python 3.14, and at the time of this writing neither
+    does pytest-twisted. This is because Python removed a number of APIs in asyncio. This
+    is a temporary workaround because they plan to remove these APIs too.
+    """
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 #envlist = checks,licenses,types,py{39,310,311,312,313}-{unittest,integration}
-envlist = checks,types,py{39,310,311,312,313}-{unittest,integration}
+envlist = checks,types,py{39,310,311,312,313,314}-{unittest,integration}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Python introduced some breaking changes[0] which cause it to no longer implicitly create an event loop. Create a new one and install it explicitly so Twisted doesn't collapse at import.

Note that Python plans to remove more APIs so this will certainly break in the future.

[0] https://docs.python.org/3/whatsnew/3.14.html#id10

Fixes: #531

Take 2 with (hopefully) a "fix" for pytest-twisted