### PR TITLE
Handle queues missing on reconnect with passive declares

### DIFF
--- a/fedora_messaging/twisted/factory.py
+++ b/fedora_messaging/twisted/factory.py
@@ -24,7 +24,7 @@ import pika.exceptions
 from twisted.internet import defer, error, protocol
 from twisted.python.failure import Failure
 
-from ..exceptions import ConnectionException
+from ..exceptions import BadDeclaration, ConnectionException
 from .consumer import Consumer
 from .protocol import BindingArgument, FedoraMessagingProtocolV2
 from .stats import ConsumerStatistics, FactoryStatistics
@@ -119,7 +119,16 @@ class FedoraMessagingFactoryV2(protocol.ReconnectingClientFactory):
             # including queues and bindings, as the queue might not have been durable
             for record in self._consumers:
                 _std_log.info("Re-registering the %r consumer", record.consumer)
-                queue_name: str = yield client.declare_queue(record.queue)
+                try:
+                    queue_name: str = yield client.declare_queue(record.queue)
+                except BadDeclaration as e:
+                    _std_log.warning(
+                        "Failed to declare queue while registering %r: %s; restarting connection.",
+                        record.consumer,
+                        str(e),
+                    )
+                    yield client.close()
+                    return
                 _remap_queue_name(record.bindings, queue_name)
                 yield client.bind_queues(record.bindings)
                 if record.consumer.callback is not None:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -954,3 +954,87 @@ def test_pub_timeout(bad_amqp_url):
             pytest.fail(f"Expected a timeout exception, not {e}")
     # Ensure the deferred has been renewed
     assert api._twisted_service.factory.when_connected().called is False
+
+
+@pytest_twisted.inlineCallbacks
+def test_passive_declare_queue_missing_on_reconnect(queue_and_binding, caplog):
+    """
+    Assert that when passive declares are enabled, the connection restarts, and declaring
+    the queue fails, the factory retries the connection.
+    """
+    queues, bindings = queue_and_binding
+    queue_name = next(iter(queues.keys()))
+    msg = message.Message(
+        topic="nice.message",
+        headers={"niceness": "very"},
+        body={"encouragement": "You're doing great!"},
+    )
+    messages_received = []
+
+    def callback(m):
+        messages_received.append(m)
+        raise exceptions.HaltConsumer()
+
+    # The consumer will create the queue, and then we'll adjust the config to not do that
+    # again. When we bonk the queue later the server will send it a 404.
+    consumers = yield api.twisted_consume(callback, bindings, queues)
+
+    config.conf["passive_declares"] = True
+    for _ in range(10):
+        conns = yield task.deferLater(
+            reactor, 1, treq.get, HTTP_API + "connections", auth=HTTP_AUTH, timeout=3
+        )
+        conns = yield conns.json()
+        this_conn = [
+            c
+            for c in conns
+            if "app" in c["client_properties"]
+            and c["client_properties"]["app"] == "test_passive_declare_queue_missing_on_reconnect"
+        ]
+        if this_conn:
+            cname = quote(this_conn[0]["name"])
+            yield treq.delete(HTTP_API + "connections/" + cname, auth=HTTP_AUTH, timeout=3)
+            resp = yield treq.delete(
+                f"{HTTP_API}queues/%2F/{queue_name}", auth=HTTP_AUTH, timeout=3
+            )
+            assert resp.code == 204
+            break
+    else:
+        pytest.fail("Unable to find and kill connection!")
+
+    # Wait for the factory to retry and fail with BadDeclaration, then disable
+    # passive declares so the next retry re-creates the queue and succeeds.
+    yield task.deferLater(reactor, 5, lambda: None)
+    config.conf["passive_declares"] = False
+    for _ in range(30):
+        resp = yield task.deferLater(
+            reactor,
+            1,
+            treq.get,
+            f"{HTTP_API}queues/%2F/{queue_name}",
+            auth=HTTP_AUTH,
+            timeout=3,
+        )
+        if resp.code == 200:
+            break
+    else:
+        yield consumers[0].cancel()
+        pytest.fail("Queue was not re-created after retry!")
+
+    yield threads.deferToThread(api.publish, msg, "amq.topic")
+
+    consumers[0].result.addTimeout(30, reactor)
+    try:
+        yield consumers[0].result
+    except exceptions.HaltConsumer:
+        assert len(messages_received) == 1
+    except (defer.TimeoutError, defer.CancelledError):
+        yield consumers[0].cancel()
+        pytest.fail("Timeout reached without consumer receiving a message!")
+
+    fm_logs = [
+        r
+        for r in caplog.records
+        if r.name.startswith("fedora_messaging.") and r.levelname == "WARNING"
+    ]
+    assert any("Failed to declare queue while registering" in r.message for r in fm_logs)

--- a/tests/unit/twisted/test_factory.py
+++ b/tests/unit/twisted/test_factory.py
@@ -11,7 +11,7 @@ from twisted.internet import defer
 from twisted.internet.error import ConnectionDone, ConnectionLost
 
 from fedora_messaging import config
-from fedora_messaging.exceptions import ConnectionException
+from fedora_messaging.exceptions import BadDeclaration, ConnectionException
 from fedora_messaging.message import Message
 from fedora_messaging.twisted.consumer import Consumer
 from fedora_messaging.twisted.factory import ConsumerRecord, FedoraMessagingFactoryV2
@@ -294,6 +294,44 @@ class TestFactoryV2:
 
         d.addCallback(_check)
         return d
+
+    @pytest_twisted.inlineCallbacks
+    def test_consume_passive_bad_declaration_reconnect(self):
+        """Assert consume handles reconnecting when queue declaration fails in passive mode."""
+        queue_name = "queue-name"
+        self.protocol.declare_queue.side_effect = [
+            BadDeclaration("queue", queue_name, "testing"),
+            lambda q: queue_name,
+        ]
+        self.protocol.bind_queues.side_effect = [
+            BadDeclaration("binding", queue_name, "testing"),
+            None,
+        ]
+        # Prepare the mocked existing consumer
+        queue_config: config.NamedQueueConfig = {
+            "queue": queue_name,
+            "durable": False,
+            "auto_delete": True,
+            "exclusive": True,
+            "arguments": {},
+        }
+        callback = mock.Mock()
+        bindings: list[BindingArgument] = [{"exchange": "amq.topic", "routing_key": "#"}]
+        consumer = Consumer(queue=queue_name, callback=callback)
+        self.factory._consumers = [
+            ConsumerRecord(consumer=consumer, queue=queue_config, bindings=bindings)
+        ]
+
+        # Try with failing declare_queue
+        self.factory.buildProtocol(None)
+        self.protocol.ready.callback(None)
+        yield self.factory.when_connected()
+
+        self.protocol.declare_queue.assert_called_once_with(queue_config)
+        self.protocol.bind_queues.assert_not_called()
+        self.protocol.consume.assert_not_called()
+        self.protocol.close.assert_called_once()
+        assert len(self.factory._consumers) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It seems that when the broker comes back up, it may accept connections before all the queues are available. Handle this by catching the exception and retrying the connection later.

Fixes #574

Note: I have only the vaguest memory how twisted works (or worked); would it be better to register an errback on the `on_ready` callback?