### PR TITLE
Protect against PEM files with no trailing newline

### DIFF
--- a/fedora_messaging/twisted/service.py
+++ b/fedora_messaging/twisted/service.py
@@ -192,6 +192,11 @@ def _ssl_context_factory(parameters: pika.connection.Parameters) -> "ClientTLSOp
         with open(key, "rb") as fd:
             client_keypair = fd.read()
         with open(cert, "rb") as fd:
+            # Insert an extra newline between the key and cert to avoid the
+            # situation where the trailer for the key shares the same line as
+            # the header for the cert. This will cause a parsing error in
+            # loadPEM().
+            client_keypair += b"\n"
             client_keypair += fd.read()
         client_cert = twisted_ssl.PrivateCertificate.loadPEM(client_keypair)
 


### PR DESCRIPTION
As discovered when attempting to deploy ELNBuildSync in Fedora Staging Infrastructure, the PEM files were lacking a trailing newline and as a result were throwing parsing errors.

Explicitly adding a newline between the files when concatenating them will avoid this potential pitfall in the future.